### PR TITLE
Added ARM64 support to the install script, manifest and build script

### DIFF
--- a/hack/build_for_arm64.sh
+++ b/hack/build_for_arm64.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+RESTIC_VERSION=0.8.3
+STASH_VERSION=0.7.0
+ARCH=arm64
+REPOSITORY=appscode
+
+GOPATH=$(go env GOPATH)
+REPO_ROOT=$GOPATH/src/github.com/appscode/stash
+
+# Build stash
+go get github.com/appscode/stash
+pushd ${REPO_ROOT}
+git checkout ${STASH_VERSION}
+export GOARCH=arm64
+go build ./...
+popd
+
+mkdir -p /build_dir
+cd /build_dir
+cp $REPO_ROOT/dist/stash/stash-alpine-amd64 ./stash
+chmod 755 ./stash
+
+# Download restic
+wget https://github.com/restic/restic/releases/download/v${RESTIC_VERSION}/restic_${RESTIC_VERSION}_linux_${ARCH}.bz2
+bzip2 -d restic_${RESTIC_VERSION}_linux_${ARCH}.bz2
+mv restic_${RESTIC_VERSION}_linux_${ARCH}.bz2 restic
+
+# Build Docker container (done on ARM64 machine)
+cat >> Dockerfile <<EOF
+FROM alpine
+
+RUN set -x \
+  && apk add --update --no-cache ca-certificates
+
+COPY restic /bin/restic
+COPY stash /bin/stash
+
+ENTRYPOINT ["/bin/stash"]
+EXPOSE 56789 56790
+EOF
+
+# Build and push image
+docker build -t ${REPOSITORY}/stash:${STASH_VERSION}-${ARCH} .
+docker push ${REPOSITORY}/stash:${STASH_VERSION}-${ARCH}
+
+# Create manifest (adjust on platform being used)
+#wget https://github.com/estesp/manifest-tool/releases/download/v0.7.0/manifest-tool-linux-amd64
+#mv manifest-tool-linux-amd64 manifest-tool
+#chmod +x manifest-tool
+
+# Generates the version manifest pointing to the arch images
+#manifest-tool push from-args --platforms linux/amd64,linux/arm64 --template "${REPOSITORY}/stash:${STASH_VERSION}-ARCH" --target "${REPOSITORY}/stash:${STASH_VERSION}"
+
+# Generates the :latest manifest pointing to the built arch images
+#manifest-tool push from-args --platforms linux/amd64,linux/arm64 --template "${REPOSITORY}/stash:${STASH_VERSION}-ARCH" --target "${REPOSITORY}/stash:latest"

--- a/hack/deploy/operator.yaml
+++ b/hack/deploy/operator.yaml
@@ -48,7 +48,7 @@ spec:
         args:
         - -web.listen-address=:56789
         - -persistence.file=/var/pv/pushgateway.dat
-        image: prom/pushgateway:v0.4.0
+        image: ${PUSHGATEWAY_DOCKER_REGISTRY}/pushgateway:v0.4.0
         ports:
         - containerPort: 56789
           name: pushgateway


### PR DESCRIPTION
The build script needs some adjustments.

To launch stash on ARM64, I used:

`./stash.sh --namespace=backup --docker-registry=carlosedp --pushgateway-registry=carlosedp --run-on-master`

Since I've built the ARM64 images for both Stash and Pushgateway.