### PR TITLE
Fix default securityContext passing to restore init-container/job

### DIFF
--- a/pkg/resolve/task.go
+++ b/pkg/resolve/task.go
@@ -3,6 +3,7 @@ package resolve
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"gomodules.xyz/envsubst"
 	core "k8s.io/api/core/v1"
@@ -63,7 +64,7 @@ func (o TaskResolver) GetPodSpec() (core.PodSpec, error) {
 
 		// container from function spec
 		container := core.Container{
-			Name:            fmt.Sprintf("%s-%d", function.Name, i), // TODO
+			Name:            fmt.Sprintf("%s-%d", strings.ReplaceAll(function.Name, ".", "-"), i), // TODO
 			Image:           function.Spec.Image,
 			Command:         function.Spec.Command,
 			Args:            function.Spec.Args,

--- a/pkg/util/init_container.go
+++ b/pkg/util/init_container.go
@@ -109,6 +109,8 @@ func NewRestoreInitContainer(rs *v1beta1_api.RestoreSession, repository *v1alpha
 	}
 	if rs.Spec.RuntimeSettings.Container != nil {
 		initContainer.SecurityContext = UpsertSecurityContext(securityContext, rs.Spec.RuntimeSettings.Container.SecurityContext)
+	} else {
+		initContainer.SecurityContext = securityContext
 	}
 
 	return initContainer

--- a/pkg/util/job.go
+++ b/pkg/util/job.go
@@ -270,6 +270,8 @@ func NewPVCRestorerJob(rs *api_v1beta1.RestoreSession, repository *api_v1alpha1.
 	}
 	if rs.Spec.RuntimeSettings.Container != nil {
 		container.SecurityContext = UpsertSecurityContext(securityContext, rs.Spec.RuntimeSettings.Container.SecurityContext)
+	} else {
+		container.SecurityContext = securityContext
 	}
 
 	jobTemplate := &core.PodTemplateSpec{


### PR DESCRIPTION
Task:
- [x] Fix default securityContext passing to restore init-container/job
- [x] Replace `.` with `-` in container name in resolved task.