### PR TITLE
Add hook tests for BackupBatch

### DIFF
--- a/pkg/backup/backupsession.go
+++ b/pkg/backup/backupsession.go
@@ -268,7 +268,6 @@ func (c *BackupSessionController) backup(invoker apis.Invoker, targetInfo apis.T
 
 	if c.InvokerType == api_v1beta1.ResourceKindBackupBatch {
 		c.SetupOpt.Path = fmt.Sprintf("%s/%s/%s", c.SetupOpt.Path, strings.ToLower(c.BackupTargetKind), c.BackupTargetName)
-
 	}
 
 	// apply nice, ionice settings from env

--- a/pkg/controller/backup_session.go
+++ b/pkg/controller/backup_session.go
@@ -132,7 +132,7 @@ func (c *StashController) applyBackupSessionReconciliationLogic(backupSession *a
 	// if backup process completed ( Failed or Succeeded), execute postBackup hook
 	if (phase == api_v1beta1.BackupSessionFailed || phase == api_v1beta1.BackupSessionSucceeded) &&
 		invoker.Hooks != nil && invoker.Hooks.PostBackup != nil {
-		err = util.ExecuteHook(c.clientConfig, invoker.Hooks.PostBackup, apis.PostBackupHook, os.Getenv("MY_POD_NAME"), os.Getenv("MY_POD_NAMESPACE"))
+		err = util.ExecuteHook(c.clientConfig, invoker.Hooks, apis.PostBackupHook, os.Getenv("MY_POD_NAME"), os.Getenv("MY_POD_NAMESPACE"))
 		if err != nil {
 			return c.setBackupSessionFailed(invoker, backupSession, err)
 		}
@@ -165,7 +165,7 @@ func (c *StashController) applyBackupSessionReconciliationLogic(backupSession *a
 
 	// if preBackup hook exist, then execute preBackupHook
 	if invoker.Hooks != nil && invoker.Hooks.PreBackup != nil {
-		err = util.ExecuteHook(c.clientConfig, invoker.Hooks.PreBackup, apis.PreBackupHook, os.Getenv("MY_POD_NAME"), os.Getenv("MY_POD_NAMESPACE"))
+		err = util.ExecuteHook(c.clientConfig, invoker.Hooks, apis.PreBackupHook, os.Getenv("MY_POD_NAME"), os.Getenv("MY_POD_NAMESPACE"))
 		if err != nil {
 			return c.setBackupSessionFailed(invoker, backupSession, err)
 		}

--- a/test/e2e/framework/service.go
+++ b/test/e2e/framework/service.go
@@ -27,15 +27,15 @@ const (
 	TEST_HEADLESS_SERVICE = "headless"
 )
 
-func (fi *Invocation) HeadlessService(label string) core.Service {
+func (fi *Invocation) HeadlessService(name string) core.Service {
 	return core.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      TEST_HEADLESS_SERVICE,
+			Name:      name,
 			Namespace: fi.namespace,
 		},
 		Spec: core.ServiceSpec{
 			Selector: map[string]string{
-				"app": label,
+				"app": name,
 			},
 			ClusterIP: core.ClusterIPNone,
 			Ports: []core.ServicePort{

--- a/test/e2e/framework/statefulset.go
+++ b/test/e2e/framework/statefulset.go
@@ -53,7 +53,7 @@ func (fi *Invocation) StatefulSet(name, pvcName, volName string) apps.StatefulSe
 			},
 			Replicas:    types.Int32P(1),
 			Template:    fi.PodTemplate(labels, pvcName, volName),
-			ServiceName: TEST_HEADLESS_SERVICE,
+			ServiceName: name,
 			UpdateStrategy: apps.StatefulSetUpdateStrategy{
 				Type: apps.RollingUpdateStatefulSetStrategyType,
 			},
@@ -77,7 +77,7 @@ func (fi *Invocation) StatefulSetForV1beta1API(name, volName string, replica int
 				MatchLabels: labels,
 			},
 			Replicas:    &replica,
-			ServiceName: TEST_HEADLESS_SERVICE,
+			ServiceName: name,
 			Template: core.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: labels,
@@ -228,8 +228,8 @@ func (fi *Invocation) DeployStatefulSet(name string, replica int32, volName stri
 	return createdss, err
 }
 
-func (fi *Invocation) DeployStatefulSetWithProbeClient() (*apps.StatefulSet, error) {
-	name := fmt.Sprintf("%s-%s", ProberDemoPodPrefix, fi.app)
+func (fi *Invocation) DeployStatefulSetWithProbeClient(name string) (*apps.StatefulSet, error) {
+	name = fmt.Sprintf("%s-%s", name, fi.app)
 	svc, err := fi.CreateService(fi.HeadlessService(name))
 	if err != nil {
 		return nil, err
@@ -251,7 +251,7 @@ func (fi *Invocation) DeployStatefulSetWithProbeClient() (*apps.StatefulSet, err
 			Selector: &metav1.LabelSelector{
 				MatchLabels: labels,
 			},
-			ServiceName: TEST_HEADLESS_SERVICE,
+			ServiceName: name,
 			Template: core.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: labels,

--- a/test/e2e/hooks/post_backup.go
+++ b/test/e2e/hooks/post_backup.go
@@ -58,7 +58,7 @@ var _ = Describe("PostBackup Hook", func() {
 					It("should execute hook successfully", func() {
 						// Deploy a StatefulSet with prober client. Here, we are using a StatefulSet because we need a stable address
 						// for pod where http request will be sent.
-						statefulset, err := f.DeployStatefulSetWithProbeClient()
+						statefulset, err := f.DeployStatefulSetWithProbeClient(framework.ProberDemoPodPrefix)
 						Expect(err).NotTo(HaveOccurred())
 
 						// Generate Sample Data
@@ -76,7 +76,7 @@ var _ = Describe("PostBackup Hook", func() {
 								PostBackup: &probev1.Handler{
 									HTTPGet: &core.HTTPGetAction{
 										Scheme: "HTTP",
-										Host:   fmt.Sprintf("%s-0.%s.%s.svc", statefulset.Name, framework.TEST_HEADLESS_SERVICE, f.Namespace()),
+										Host:   fmt.Sprintf("%s-0.%s.%s.svc", statefulset.Name, statefulset.Name, f.Namespace()),
 										Path:   "/success",
 										Port:   intstr.FromInt(framework.HttpPort),
 									},
@@ -102,7 +102,7 @@ var _ = Describe("PostBackup Hook", func() {
 				Context("Host and Port from Pod", func() {
 					It("should execute hook successfully", func() {
 						// Deploy a StatefulSet.
-						statefulset, err := f.DeployStatefulSetWithProbeClient()
+						statefulset, err := f.DeployStatefulSetWithProbeClient(framework.ProberDemoPodPrefix)
 						Expect(err).NotTo(HaveOccurred())
 
 						// Generate Sample Data
@@ -147,7 +147,7 @@ var _ = Describe("PostBackup Hook", func() {
 			Context("Failure Test", func() {
 				It("should take a backup even when the postBackup hook failed", func() {
 					// Deploy a StatefulSet.
-					statefulset, err := f.DeployStatefulSetWithProbeClient()
+					statefulset, err := f.DeployStatefulSetWithProbeClient(framework.ProberDemoPodPrefix)
 					Expect(err).NotTo(HaveOccurred())
 
 					// Generate Sample Data
@@ -202,7 +202,7 @@ var _ = Describe("PostBackup Hook", func() {
 					It("should execute hook successfully", func() {
 						// Deploy a StatefulSet with prober client. Here, we are using a StatefulSet because we need a stable address
 						// for pod where http request will be sent.
-						statefulset, err := f.DeployStatefulSetWithProbeClient()
+						statefulset, err := f.DeployStatefulSetWithProbeClient(framework.ProberDemoPodPrefix)
 						Expect(err).NotTo(HaveOccurred())
 
 						// Generate Sample Data
@@ -220,7 +220,7 @@ var _ = Describe("PostBackup Hook", func() {
 								PostBackup: &probev1.Handler{
 									HTTPPost: &probev1.HTTPPostAction{
 										Scheme: "HTTP",
-										Host:   fmt.Sprintf("%s-0.%s.%s.svc", statefulset.Name, framework.TEST_HEADLESS_SERVICE, f.Namespace()),
+										Host:   fmt.Sprintf("%s-0.%s.%s.svc", statefulset.Name, statefulset.Name, f.Namespace()),
 										Path:   "/post-demo",
 										Port:   intstr.FromInt(framework.HttpPort),
 									},
@@ -246,7 +246,7 @@ var _ = Describe("PostBackup Hook", func() {
 				Context("Host and Port from Pod", func() {
 					It("should execute hook successfully", func() {
 						// Deploy a StatefulSet.
-						statefulset, err := f.DeployStatefulSetWithProbeClient()
+						statefulset, err := f.DeployStatefulSetWithProbeClient(framework.ProberDemoPodPrefix)
 						Expect(err).NotTo(HaveOccurred())
 
 						// Generate Sample Data
@@ -290,7 +290,7 @@ var _ = Describe("PostBackup Hook", func() {
 				Context("Json Data in Request Body", func() {
 					It("server should echo the 'expectedCode' and 'expectedResponse' passed in the json body", func() {
 						// Deploy a StatefulSet.
-						statefulset, err := f.DeployStatefulSetWithProbeClient()
+						statefulset, err := f.DeployStatefulSetWithProbeClient(framework.ProberDemoPodPrefix)
 						Expect(err).NotTo(HaveOccurred())
 
 						// Generate Sample Data
@@ -335,7 +335,7 @@ var _ = Describe("PostBackup Hook", func() {
 				Context("Form Data in Request Body", func() {
 					It("server should echo the 'expectedCode' and 'expectedResponse' passed as form data", func() {
 						// Deploy a StatefulSet.
-						statefulset, err := f.DeployStatefulSetWithProbeClient()
+						statefulset, err := f.DeployStatefulSetWithProbeClient(framework.ProberDemoPodPrefix)
 						Expect(err).NotTo(HaveOccurred())
 
 						// Generate Sample Data
@@ -390,7 +390,7 @@ var _ = Describe("PostBackup Hook", func() {
 			Context("Failure Test", func() {
 				It("should take a backup even when the postBackup hook failed", func() {
 					// Deploy a StatefulSet.
-					statefulset, err := f.DeployStatefulSetWithProbeClient()
+					statefulset, err := f.DeployStatefulSetWithProbeClient(framework.ProberDemoPodPrefix)
 					Expect(err).NotTo(HaveOccurred())
 
 					// Generate Sample Data
@@ -455,7 +455,7 @@ var _ = Describe("PostBackup Hook", func() {
 					It("should execute hook successfully", func() {
 						// Deploy a StatefulSet with prober client. Here, we are using a StatefulSet because we need a stable address
 						// for pod where http request will be sent.
-						statefulset, err := f.DeployStatefulSetWithProbeClient()
+						statefulset, err := f.DeployStatefulSetWithProbeClient(framework.ProberDemoPodPrefix)
 						Expect(err).NotTo(HaveOccurred())
 
 						// Generate Sample Data
@@ -472,7 +472,7 @@ var _ = Describe("PostBackup Hook", func() {
 							bc.Spec.Hooks = &v1beta1.BackupHooks{
 								PostBackup: &probev1.Handler{
 									TCPSocket: &core.TCPSocketAction{
-										Host: fmt.Sprintf("%s-0.%s.%s.svc", statefulset.Name, framework.TEST_HEADLESS_SERVICE, f.Namespace()),
+										Host: fmt.Sprintf("%s-0.%s.%s.svc", statefulset.Name, statefulset.Name, f.Namespace()),
 										Port: intstr.FromInt(framework.TcpPort),
 									},
 								},
@@ -497,7 +497,7 @@ var _ = Describe("PostBackup Hook", func() {
 				Context("Host and Port from Pod", func() {
 					It("should execute hook successfully", func() {
 						// Deploy a StatefulSet.
-						statefulset, err := f.DeployStatefulSetWithProbeClient()
+						statefulset, err := f.DeployStatefulSetWithProbeClient(framework.ProberDemoPodPrefix)
 						Expect(err).NotTo(HaveOccurred())
 
 						// Generate Sample Data
@@ -540,7 +540,7 @@ var _ = Describe("PostBackup Hook", func() {
 			Context("Failure Test", func() {
 				It("should take a backup even when the postBackup hook failed", func() {
 					// Deploy a StatefulSet.
-					statefulset, err := f.DeployStatefulSetWithProbeClient()
+					statefulset, err := f.DeployStatefulSetWithProbeClient(framework.ProberDemoPodPrefix)
 					Expect(err).NotTo(HaveOccurred())
 
 					// Generate Sample Data
@@ -591,7 +591,7 @@ var _ = Describe("PostBackup Hook", func() {
 			Context("Success Test", func() {
 				It("should cleanup the sample data in postBackup hook", func() {
 					// Deploy a StatefulSet.
-					statefulset, err := f.DeployStatefulSetWithProbeClient()
+					statefulset, err := f.DeployStatefulSetWithProbeClient(framework.ProberDemoPodPrefix)
 					Expect(err).NotTo(HaveOccurred())
 
 					// Read data at empty state
@@ -641,7 +641,7 @@ var _ = Describe("PostBackup Hook", func() {
 
 				It("should execute postBackup hook even when the backup process failed", func() {
 					// Deploy a StatefulSet.
-					statefulset, err := f.DeployStatefulSetWithProbeClient()
+					statefulset, err := f.DeployStatefulSetWithProbeClient(framework.ProberDemoPodPrefix)
 					Expect(err).NotTo(HaveOccurred())
 
 					// Read data at empty state
@@ -696,7 +696,7 @@ var _ = Describe("PostBackup Hook", func() {
 			Context("Failure Test", func() {
 				It("should take a backup even when the postBackup hook failed", func() {
 					// Deploy a StatefulSet.
-					statefulset, err := f.DeployStatefulSetWithProbeClient()
+					statefulset, err := f.DeployStatefulSetWithProbeClient(framework.ProberDemoPodPrefix)
 					Expect(err).NotTo(HaveOccurred())
 
 					// Read data at empty state

--- a/test/e2e/hooks/post_restore.go
+++ b/test/e2e/hooks/post_restore.go
@@ -59,7 +59,7 @@ var _ = Describe("PostRestore Hook", func() {
 				It("should execute the postRestore hook successfully", func() {
 					// Deploy a StatefulSet with prober client. Here, we are using a StatefulSet because we need a stable address
 					// for pod where http request will be sent.
-					statefulset, err := f.DeployStatefulSetWithProbeClient()
+					statefulset, err := f.DeployStatefulSetWithProbeClient(framework.ProberDemoPodPrefix)
 					Expect(err).NotTo(HaveOccurred())
 
 					// Read data at empty state
@@ -130,7 +130,7 @@ var _ = Describe("PostRestore Hook", func() {
 				It("should execute the postRestore hook even when the restore process failed", func() {
 					// Deploy a StatefulSet with prober client. Here, we are using a StatefulSet because we need a stable address
 					// for pod where http request will be sent.
-					statefulset, err := f.DeployStatefulSetWithProbeClient()
+					statefulset, err := f.DeployStatefulSetWithProbeClient(framework.ProberDemoPodPrefix)
 					Expect(err).NotTo(HaveOccurred())
 
 					// Read data at empty state
@@ -219,7 +219,7 @@ var _ = Describe("PostRestore Hook", func() {
 				It("should restore backed up data even when the hook failed", func() {
 					// Deploy a StatefulSet with prober client. Here, we are using a StatefulSet because we need a stable address
 					// for pod where http request will be sent.
-					statefulset, err := f.DeployStatefulSetWithProbeClient()
+					statefulset, err := f.DeployStatefulSetWithProbeClient(framework.ProberDemoPodPrefix)
 					Expect(err).NotTo(HaveOccurred())
 
 					// Read data at empty state

--- a/test/e2e/hooks/pre_backup.go
+++ b/test/e2e/hooks/pre_backup.go
@@ -40,7 +40,9 @@ import (
 var _ = Describe("PreBackup Hook", func() {
 
 	var f *framework.Invocation
-
+	const (
+		sampleTable = "StashDemo"
+	)
 	BeforeEach(func() {
 		f = framework.NewInvocation()
 	})
@@ -840,10 +842,6 @@ var _ = Describe("PreBackup Hook", func() {
 			})
 
 			Context("MySQL", func() {
-				const (
-					sampleTable = "StashDemo"
-				)
-
 				BeforeEach(func() {
 					// Skip test if respective Functions and Tasks are not installed.
 					if !f.MySQLAddonInstalled() {
@@ -1006,7 +1004,7 @@ var _ = Describe("PreBackup Hook", func() {
 
 	Context("Batch Backup", func() {
 		Context("HTTPGetAction", func() {
-			It("should execute all global and local hooks successfully", func() {
+			It("should execute global and local hooks successfully", func() {
 				// Here, we are going to deploy two different StatefulSet with probe client.
 				// Then, we are going to backup those StatefulSets using BatchBackup.
 				// Each individual StatefulSet will have a hook for them.
@@ -1123,7 +1121,132 @@ var _ = Describe("PreBackup Hook", func() {
 		})
 
 		Context("ExecAction", func() {
+			It("should execute global and local hooks successfully", func() {
+				// Here, we are going to deploy two different types of workload.
+				// First workload is a StatefulSet with probe client. We will execute a simple http hook there. The other workload is a database.
+				// We will make the database readonly in local hook. We will execute a simple exec action in global hook.
+				var members []v1beta1.BackupConfigurationTemplateSpec
 
+				// Deploy the first StatefulSet.
+				ss1, err := f.DeployStatefulSetWithProbeClient(framework.ProberDemoPodPrefix)
+				Expect(err).NotTo(HaveOccurred())
+				// Generate Sample Data
+				_, err = f.GenerateSampleData(ss1.ObjectMeta, apis.KindStatefulSet)
+				Expect(err).NotTo(HaveOccurred())
+				// We will execute HTTPGetAction in the first StatefulSet
+				members = append(members, v1beta1.BackupConfigurationTemplateSpec{
+					Hooks: &v1beta1.BackupHooks{
+						PreBackup: &probev1.Handler{
+							HTTPGet: &core.HTTPGetAction{
+								Scheme: "HTTP",
+								Host:   fmt.Sprintf("%s-0.%s.%s.svc", ss1.Name, ss1.Name, f.Namespace()),
+								Path:   "/success",
+								Port:   intstr.FromInt(framework.HttpPort),
+							},
+						},
+					},
+					Target: &v1beta1.BackupTarget{
+						Ref: v1beta1.TargetRef{
+							APIVersion: appsv1.SchemeGroupVersion.String(),
+							Kind:       apis.KindStatefulSet,
+							Name:       ss1.Name,
+						},
+						Paths: []string{
+							framework.TestSourceDataMountPath,
+						},
+						VolumeMounts: []core.VolumeMount{
+							{
+								Name:      framework.SourceVolume,
+								MountPath: framework.TestSourceDataMountPath,
+							},
+						},
+					},
+				})
+
+				// Deploy MySQL database and respective service,secret,PVC and AppBinding.
+				By("Deploying MySQL Server")
+				dpl, appBinding, err := f.DeployMySQLDatabase()
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Port forwarding MySQL pod")
+				pod, err := f.GetPod(dpl.ObjectMeta)
+				Expect(err).NotTo(HaveOccurred())
+				tunnel := pfutil.NewTunnel(f.KubeClient.CoreV1().RESTClient(), f.ClientConfig, pod.Namespace, pod.Name, framework.MySQLServingPortNumber)
+				defer tunnel.Close()
+				err = tunnel.ForwardPort()
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Connecting with MySQL Server")
+				connstr := fmt.Sprintf("%s:%s@tcp(%s:%d)/mysql", framework.SuperUser, f.App(), framework.LocalHostIP, tunnel.Local)
+				db, err := sql.Open("mysql", connstr)
+				Expect(err).NotTo(HaveOccurred())
+				defer db.Close()
+				db.SetConnMaxLifetime(time.Second * 10)
+				err = f.EventuallyConnectWithMySQLServer(db)
+				Expect(err).NotTo(HaveOccurred())
+
+				// add the database as member of batch backup
+				members = append(members, v1beta1.BackupConfigurationTemplateSpec{
+					// make the database readonly in preBackup hook.
+					Hooks: &v1beta1.BackupHooks{
+						PreBackup: &probev1.Handler{
+							Exec: &core.ExecAction{
+								Command: []string{"/bin/sh", "-c",
+									`mysql -u root --password=$MYSQL_ROOT_PASSWORD -e "SET GLOBAL super_read_only = ON;"`},
+							},
+							ContainerName: framework.MySQLContainerName,
+						},
+					},
+					Task: v1beta1.TaskRef{
+						Name: framework.MySQLBackupTask,
+					},
+					Target: &v1beta1.BackupTarget{
+						Ref: v1beta1.TargetRef{
+							APIVersion: core.SchemeGroupVersion.String(),
+							Kind:       apis.KindAppBinding,
+							Name:       appBinding.Name,
+						},
+					},
+				})
+
+				// Setup a Minio Repository
+				repo, err := f.SetupMinioRepository()
+				Expect(err).NotTo(HaveOccurred())
+				f.AppendToCleanupList(repo)
+
+				// Setup Batch Backup
+				backupBatch, err := f.SetupBatchBackup(repo, func(in *v1beta1.BackupBatch) {
+					in.Spec.Members = members
+					// Execute a simple exec hook in the global hook. This hook will be executed inside Stash operator.
+					// Currently, we don't have any known command that really make sense to execute inside operator.
+					// So, we are using the simplest command to test the global hook. :P
+					in.Spec.Hooks = &v1beta1.BackupHooks{
+						PreBackup: &probev1.Handler{
+							Exec: &core.ExecAction{
+								Command: []string{"/bin/sh", "-c", "exit 0"},
+							},
+							ContainerName: "operator",
+						},
+					}
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				// Take an Instant Backup the Sample Data
+				backupSession, err := f.TakeInstantBackup(backupBatch.ObjectMeta, v1beta1.BackupInvokerRef{
+					Name: backupBatch.Name,
+					Kind: v1beta1.ResourceKindBackupBatch,
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Verifying that BackupSession has succeeded")
+				completedBS, err := f.StashClient.StashV1beta1().BackupSessions(backupSession.Namespace).Get(backupSession.Name, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(completedBS.Status.Phase).Should(Equal(v1beta1.BackupSessionSucceeded))
+
+				By("Verifying that the database is read-only")
+				err = f.CreateTable(db, "readOnlyTest")
+				Expect(err).Should(HaveOccurred())
+			})
 		})
 
 		Context("Different Situations", func() {

--- a/test/e2e/hooks/pre_backup.go
+++ b/test/e2e/hooks/pre_backup.go
@@ -29,6 +29,7 @@ import (
 	_ "github.com/go-sql-driver/mysql"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -60,7 +61,7 @@ var _ = Describe("PreBackup Hook", func() {
 					It("should execute probe successfully", func() {
 						// Deploy a StatefulSet with prober client. Here, we are using a StatefulSet because we need a stable address
 						// for pod where http request will be sent.
-						statefulset, err := f.DeployStatefulSetWithProbeClient()
+						statefulset, err := f.DeployStatefulSetWithProbeClient(framework.ProberDemoPodPrefix)
 						Expect(err).NotTo(HaveOccurred())
 
 						// Generate Sample Data
@@ -78,7 +79,7 @@ var _ = Describe("PreBackup Hook", func() {
 								PreBackup: &probev1.Handler{
 									HTTPGet: &core.HTTPGetAction{
 										Scheme: "HTTP",
-										Host:   fmt.Sprintf("%s-0.%s.%s.svc", statefulset.Name, framework.TEST_HEADLESS_SERVICE, f.Namespace()),
+										Host:   fmt.Sprintf("%s-0.%s.%s.svc", statefulset.Name, statefulset.Name, f.Namespace()),
 										Path:   "/success",
 										Port:   intstr.FromInt(framework.HttpPort),
 									},
@@ -104,7 +105,7 @@ var _ = Describe("PreBackup Hook", func() {
 				Context("Host and Port from Pod", func() {
 					It("should execute probe successfully", func() {
 						// Deploy a StatefulSet.
-						statefulset, err := f.DeployStatefulSetWithProbeClient()
+						statefulset, err := f.DeployStatefulSetWithProbeClient(framework.ProberDemoPodPrefix)
 						Expect(err).NotTo(HaveOccurred())
 
 						// Generate Sample Data
@@ -149,7 +150,7 @@ var _ = Describe("PreBackup Hook", func() {
 			Context("Failure Test", func() {
 				It("should not take backup when probe failed", func() {
 					// Deploy a StatefulSet.
-					statefulset, err := f.DeployStatefulSetWithProbeClient()
+					statefulset, err := f.DeployStatefulSetWithProbeClient(framework.ProberDemoPodPrefix)
 					Expect(err).NotTo(HaveOccurred())
 
 					// Generate Sample Data
@@ -210,7 +211,7 @@ var _ = Describe("PreBackup Hook", func() {
 					It("should execute probe successfully", func() {
 						// Deploy a StatefulSet with prober client. Here, we are using a StatefulSet because we need a stable address
 						// for pod where http request will be sent.
-						statefulset, err := f.DeployStatefulSetWithProbeClient()
+						statefulset, err := f.DeployStatefulSetWithProbeClient(framework.ProberDemoPodPrefix)
 						Expect(err).NotTo(HaveOccurred())
 
 						// Generate Sample Data
@@ -228,7 +229,7 @@ var _ = Describe("PreBackup Hook", func() {
 								PreBackup: &probev1.Handler{
 									HTTPPost: &probev1.HTTPPostAction{
 										Scheme: "HTTP",
-										Host:   fmt.Sprintf("%s-0.%s.%s.svc", statefulset.Name, framework.TEST_HEADLESS_SERVICE, f.Namespace()),
+										Host:   fmt.Sprintf("%s-0.%s.%s.svc", statefulset.Name, statefulset.Name, f.Namespace()),
 										Path:   "/post-demo",
 										Port:   intstr.FromInt(framework.HttpPort),
 									},
@@ -254,7 +255,7 @@ var _ = Describe("PreBackup Hook", func() {
 				Context("Host and Port from Pod", func() {
 					It("should execute probe successfully", func() {
 						// Deploy a StatefulSet.
-						statefulset, err := f.DeployStatefulSetWithProbeClient()
+						statefulset, err := f.DeployStatefulSetWithProbeClient(framework.ProberDemoPodPrefix)
 						Expect(err).NotTo(HaveOccurred())
 
 						// Generate Sample Data
@@ -298,7 +299,7 @@ var _ = Describe("PreBackup Hook", func() {
 				Context("Json Data in Request Body", func() {
 					It("server should echo the 'expectedCode' and 'expectedResponse' passed in the json body", func() {
 						// Deploy a StatefulSet.
-						statefulset, err := f.DeployStatefulSetWithProbeClient()
+						statefulset, err := f.DeployStatefulSetWithProbeClient(framework.ProberDemoPodPrefix)
 						Expect(err).NotTo(HaveOccurred())
 
 						// Generate Sample Data
@@ -343,7 +344,7 @@ var _ = Describe("PreBackup Hook", func() {
 				Context("Form Data in Request Body", func() {
 					It("server should echo the 'expectedCode' and 'expectedResponse' passed as form data", func() {
 						// Deploy a StatefulSet.
-						statefulset, err := f.DeployStatefulSetWithProbeClient()
+						statefulset, err := f.DeployStatefulSetWithProbeClient(framework.ProberDemoPodPrefix)
 						Expect(err).NotTo(HaveOccurred())
 
 						// Generate Sample Data
@@ -398,7 +399,7 @@ var _ = Describe("PreBackup Hook", func() {
 			Context("Failure Test", func() {
 				It("should not take backup when probe failed", func() {
 					// Deploy a StatefulSet.
-					statefulset, err := f.DeployStatefulSetWithProbeClient()
+					statefulset, err := f.DeployStatefulSetWithProbeClient(framework.ProberDemoPodPrefix)
 					Expect(err).NotTo(HaveOccurred())
 
 					// Generate Sample Data
@@ -469,7 +470,7 @@ var _ = Describe("PreBackup Hook", func() {
 					It("should execute probe successfully", func() {
 						// Deploy a StatefulSet with prober client. Here, we are using a StatefulSet because we need a stable address
 						// for pod where http request will be sent.
-						statefulset, err := f.DeployStatefulSetWithProbeClient()
+						statefulset, err := f.DeployStatefulSetWithProbeClient(framework.ProberDemoPodPrefix)
 						Expect(err).NotTo(HaveOccurred())
 
 						// Generate Sample Data
@@ -486,7 +487,7 @@ var _ = Describe("PreBackup Hook", func() {
 							bc.Spec.Hooks = &v1beta1.BackupHooks{
 								PreBackup: &probev1.Handler{
 									TCPSocket: &core.TCPSocketAction{
-										Host: fmt.Sprintf("%s-0.%s.%s.svc", statefulset.Name, framework.TEST_HEADLESS_SERVICE, f.Namespace()),
+										Host: fmt.Sprintf("%s-0.%s.%s.svc", statefulset.Name, statefulset.Name, f.Namespace()),
 										Port: intstr.FromInt(framework.TcpPort),
 									},
 								},
@@ -511,7 +512,7 @@ var _ = Describe("PreBackup Hook", func() {
 				Context("Host and Port from Pod", func() {
 					It("should execute probe successfully", func() {
 						// Deploy a StatefulSet.
-						statefulset, err := f.DeployStatefulSetWithProbeClient()
+						statefulset, err := f.DeployStatefulSetWithProbeClient(framework.ProberDemoPodPrefix)
 						Expect(err).NotTo(HaveOccurred())
 
 						// Generate Sample Data
@@ -554,7 +555,7 @@ var _ = Describe("PreBackup Hook", func() {
 			Context("Failure Test", func() {
 				It("should not take backup when probe failed", func() {
 					// Deploy a StatefulSet.
-					statefulset, err := f.DeployStatefulSetWithProbeClient()
+					statefulset, err := f.DeployStatefulSetWithProbeClient(framework.ProberDemoPodPrefix)
 					Expect(err).NotTo(HaveOccurred())
 
 					// Generate Sample Data
@@ -611,7 +612,7 @@ var _ = Describe("PreBackup Hook", func() {
 			Context("Success Test", func() {
 				It("should execute probe successfully", func() {
 					// Deploy a StatefulSet.
-					statefulset, err := f.DeployStatefulSetWithProbeClient()
+					statefulset, err := f.DeployStatefulSetWithProbeClient(framework.ProberDemoPodPrefix)
 					Expect(err).NotTo(HaveOccurred())
 
 					// Generate Sample Data
@@ -653,7 +654,7 @@ var _ = Describe("PreBackup Hook", func() {
 			Context("Failure Test", func() {
 				It("should not take backup when probe failed", func() {
 					// Deploy a StatefulSet.
-					statefulset, err := f.DeployStatefulSetWithProbeClient()
+					statefulset, err := f.DeployStatefulSetWithProbeClient(framework.ProberDemoPodPrefix)
 					Expect(err).NotTo(HaveOccurred())
 
 					// Generate Sample Data
@@ -1000,6 +1001,133 @@ var _ = Describe("PreBackup Hook", func() {
 					})
 				})
 			})
+		})
+	})
+
+	Context("Batch Backup", func() {
+		Context("HTTPGetAction", func() {
+			It("should execute all global and local hooks successfully", func() {
+				// Here, we are going to deploy two different StatefulSet with probe client.
+				// Then, we are going to backup those StatefulSets using BatchBackup.
+				// Each individual StatefulSet will have a hook for them.
+				// The BackupBatch object will have a global hook.
+				var members []v1beta1.BackupConfigurationTemplateSpec
+
+				// Deploy the first StatefulSet.
+				ss1, err := f.DeployStatefulSetWithProbeClient(framework.ProberDemoPodPrefix + "-1")
+				Expect(err).NotTo(HaveOccurred())
+				// Generate Sample Data
+				_, err = f.GenerateSampleData(ss1.ObjectMeta, apis.KindStatefulSet)
+				Expect(err).NotTo(HaveOccurred())
+				// We will execute HTTPGetAction in the first StatefulSet
+				members = append(members, v1beta1.BackupConfigurationTemplateSpec{
+					Hooks: &v1beta1.BackupHooks{
+						PreBackup: &probev1.Handler{
+							HTTPGet: &core.HTTPGetAction{
+								Scheme: "HTTP",
+								Host:   fmt.Sprintf("%s-0.%s.%s.svc", ss1.Name, ss1.Name, f.Namespace()),
+								Path:   "/success",
+								Port:   intstr.FromInt(framework.HttpPort),
+							},
+						},
+					},
+					Target: &v1beta1.BackupTarget{
+						Ref: v1beta1.TargetRef{
+							APIVersion: appsv1.SchemeGroupVersion.String(),
+							Kind:       apis.KindStatefulSet,
+							Name:       ss1.Name,
+						},
+						Paths: []string{
+							framework.TestSourceDataMountPath,
+						},
+						VolumeMounts: []core.VolumeMount{
+							{
+								Name:      framework.SourceVolume,
+								MountPath: framework.TestSourceDataMountPath,
+							},
+						},
+					},
+				})
+
+				// Deploy second StatefulSet
+				ss2, err := f.DeployStatefulSetWithProbeClient(framework.ProberDemoPodPrefix + "-2")
+				Expect(err).NotTo(HaveOccurred())
+				// Generate Sample Data
+				_, err = f.GenerateSampleData(ss2.ObjectMeta, apis.KindStatefulSet)
+				Expect(err).NotTo(HaveOccurred())
+				// We will execute HTTPPostAction in the second StatefulSet
+				members = append(members, v1beta1.BackupConfigurationTemplateSpec{
+					Hooks: &v1beta1.BackupHooks{
+						PreBackup: &probev1.Handler{
+							HTTPPost: &probev1.HTTPPostAction{
+								Scheme: "HTTP",
+								Host:   fmt.Sprintf("%s-0.%s.%s.svc", ss2.Name, ss2.Name, f.Namespace()),
+								Path:   "/post-demo",
+								Port:   intstr.FromInt(framework.HttpPort),
+							},
+						},
+					},
+					Target: &v1beta1.BackupTarget{
+						Ref: v1beta1.TargetRef{
+							APIVersion: appsv1.SchemeGroupVersion.String(),
+							Kind:       apis.KindStatefulSet,
+							Name:       ss2.Name,
+						},
+						Paths: []string{
+							framework.TestSourceDataMountPath,
+						},
+						VolumeMounts: []core.VolumeMount{
+							{
+								Name:      framework.SourceVolume,
+								MountPath: framework.TestSourceDataMountPath,
+							},
+						},
+					},
+				})
+
+				// Setup a Minio Repository
+				repo, err := f.SetupMinioRepository()
+				Expect(err).NotTo(HaveOccurred())
+				f.AppendToCleanupList(repo)
+
+				// Setup Batch Backup
+				backupBatch, err := f.SetupBatchBackup(repo, func(in *v1beta1.BackupBatch) {
+					in.Spec.Members = members
+					in.Spec.Hooks = &v1beta1.BackupHooks{
+						// Just simply execute a http probe in the first StatefulSet.
+						// Although it does not represent the actual use case, but it probes that the global are working.
+						PreBackup: &probev1.Handler{
+							HTTPGet: &core.HTTPGetAction{
+								Scheme: "HTTP",
+								Host:   fmt.Sprintf("%s-0.%s.%s.svc", ss1.Name, ss1.Name, f.Namespace()),
+								Path:   "/success",
+								Port:   intstr.FromInt(framework.HttpPort),
+							},
+						},
+					}
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				// Take an Instant Backup the Sample Data
+				backupSession, err := f.TakeInstantBackup(backupBatch.ObjectMeta, v1beta1.BackupInvokerRef{
+					Name: backupBatch.Name,
+					Kind: v1beta1.ResourceKindBackupBatch,
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Verifying that BackupSession has succeeded")
+				completedBS, err := f.StashClient.StashV1beta1().BackupSessions(backupSession.Namespace).Get(backupSession.Name, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(completedBS.Status.Phase).Should(Equal(v1beta1.BackupSessionSucceeded))
+			})
+		})
+
+		Context("ExecAction", func() {
+
+		})
+
+		Context("Different Situations", func() {
+
 		})
 	})
 })

--- a/test/e2e/hooks/pre_backup.go
+++ b/test/e2e/hooks/pre_backup.go
@@ -1133,15 +1133,12 @@ var _ = Describe("PreBackup Hook", func() {
 				// Generate Sample Data
 				_, err = f.GenerateSampleData(ss1.ObjectMeta, apis.KindStatefulSet)
 				Expect(err).NotTo(HaveOccurred())
-				// We will execute HTTPGetAction in the first StatefulSet
+				// We will execute an ExecAction in the StatefulSet
 				members = append(members, v1beta1.BackupConfigurationTemplateSpec{
 					Hooks: &v1beta1.BackupHooks{
 						PreBackup: &probev1.Handler{
-							HTTPGet: &core.HTTPGetAction{
-								Scheme: "HTTP",
-								Host:   fmt.Sprintf("%s-0.%s.%s.svc", ss1.Name, ss1.Name, f.Namespace()),
-								Path:   "/success",
-								Port:   intstr.FromInt(framework.HttpPort),
+							Exec: &core.ExecAction{
+								Command: []string{"/bin/sh", "-c", `exit $EXIT_CODE_SUCCESS`},
 							},
 						},
 					},
@@ -1371,7 +1368,7 @@ var _ = Describe("PreBackup Hook", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(completedBS.Status.Phase).Should(Equal(v1beta1.BackupSessionFailed))
 
-				By("Verifying that the database is read-only") // this ensure that the local preBackup hook hasn't been executed.
+				By("Verifying that the database is writable") // this ensure that the local preBackup hook hasn't been executed.
 				err = f.CreateTable(db, "readOnlyTest")
 				Expect(err).ShouldNot(HaveOccurred())
 

--- a/test/e2e/hooks/pre_restore.go
+++ b/test/e2e/hooks/pre_restore.go
@@ -59,7 +59,7 @@ var _ = Describe("PreRestore Hook", func() {
 				It("should remove the corrupted data in preRestore hook", func() {
 					// Deploy a StatefulSet with prober client. Here, we are using a StatefulSet because we need a stable address
 					// for pod where http request will be sent.
-					statefulset, err := f.DeployStatefulSetWithProbeClient()
+					statefulset, err := f.DeployStatefulSetWithProbeClient(framework.ProberDemoPodPrefix)
 					Expect(err).NotTo(HaveOccurred())
 
 					// Read data at empty state
@@ -131,7 +131,7 @@ var _ = Describe("PreRestore Hook", func() {
 				It("should not restore when preRestore hook failed", func() {
 					// Deploy a StatefulSet with prober client. Here, we are using a StatefulSet because we need a stable address
 					// for pod where http request will be sent.
-					statefulset, err := f.DeployStatefulSetWithProbeClient()
+					statefulset, err := f.DeployStatefulSetWithProbeClient(framework.ProberDemoPodPrefix)
 					Expect(err).NotTo(HaveOccurred())
 
 					// Read data at empty state


### PR DESCRIPTION
Tasks:
- [x] PreBackup Hook
- [x] Post Backup Hooks

Test Types:
- [x] HTTP probe (covers HTTPGetAction, HTTPPostAction, and TCPSocketAction).
- [x] ExecAction
- [x] Different Situations
	- [x] Global preBackup hook fail ( should not execute member's hook and backup process)
	- [x] Global postBackup hook fail ( should fail BackupSession but backup data will be present).
	- [x] One of the target fail ( should execute global postBackup hook even if a target fail).