### PR TITLE
Fix ServiceAccount name mitchmatch

### DIFF
--- a/apis/constants.go
+++ b/apis/constants.go
@@ -96,8 +96,10 @@ const (
 )
 
 const (
-	PrefixStashBackup    = "stash-backup"
-	PrefixStashRestore   = "stash-restore"
+	PrefixStashBackup         = "stash-backup"
+	PrefixStashRestore        = "stash-restore"
+	PrefixStashVolumeSnapshot = "stash-vs"
+
 	StashContainer       = "stash"
 	StashInitContainer   = "stash-init"
 	LocalVolumeName      = "stash-local"
@@ -146,4 +148,26 @@ const (
 	CallerController    = "controller"
 	PushgatewayLocalURL = "http://localhost:56789"
 	DefaultHost         = "host-0"
+)
+
+// Prometheus metrics related constants
+const (
+	PromJobStashBackup  = "stash-backup"
+	PromJobStashRestore = "stash-restore"
+)
+
+// RBAC related constants
+const (
+	KindRole        = "Role"
+	KindClusterRole = "ClusterRole"
+
+	StashBackupJobClusterRole            = "stash-backup-job"
+	StashRestoreJobClusterRole           = "stash-restore-job"
+	StashCronJobClusterRole              = "stash-cron-job"
+	StashSidecarClusterRole              = "stash-sidecar"
+	StashRestoreInitContainerClusterRole = "stash-restore-init-container"
+
+	StashVolumeSnapshotterClusterRole      = "stash-vs-job"
+	StashVolumeSnapshotRestorerClusterRole = "stash-vs-restorer-job"
+	StashStorageClassReaderClusterRole     = "stash-sc-reader"
 )

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	k8s.io/kube-aggregator v0.0.0-20191114103820-f023614fb9ea
 	k8s.io/kube-openapi v0.0.0-20191107075043-30be4d16710a
 	k8s.io/kubernetes v1.16.3
-	kmodules.xyz/client-go v0.0.0-20200105092743-4b797c0c0802
+	kmodules.xyz/client-go v0.0.0-20200116162153-e083ae16abca
 	kmodules.xyz/constants v0.0.0-20191024095500-cd4313df4aa6
 	kmodules.xyz/crd-schema-fuzz v0.0.0-20191129174258-81f984340891
 	kmodules.xyz/custom-resources v0.0.0-20191130062942-f41b54f62419

--- a/go.sum
+++ b/go.sum
@@ -689,8 +689,8 @@ k8s.io/utils v0.0.0-20190801114015-581e00157fb1 h1:+ySTxfHnfzZb9ys375PXNlLhkJPLK
 k8s.io/utils v0.0.0-20190801114015-581e00157fb1/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 kmodules.xyz/client-go v0.0.0-20191127054604-26981530831d/go.mod h1:OFxuKCiVR+MYlR2a08FkfaF+IbXkLe0xBetu2LTUuGI=
 kmodules.xyz/client-go v0.0.0-20191211192817-f1dcd02124ba/go.mod h1:OFxuKCiVR+MYlR2a08FkfaF+IbXkLe0xBetu2LTUuGI=
-kmodules.xyz/client-go v0.0.0-20200105092743-4b797c0c0802 h1:INQ3RPEcdLX4m7Ql+eTyDjtRYrQlK/D9hrcDuAijw6c=
-kmodules.xyz/client-go v0.0.0-20200105092743-4b797c0c0802/go.mod h1:OFxuKCiVR+MYlR2a08FkfaF+IbXkLe0xBetu2LTUuGI=
+kmodules.xyz/client-go v0.0.0-20200116162153-e083ae16abca h1:WErv3VRRePgp4oszIHgrFnxIaIHyfP9+930B99B8BBM=
+kmodules.xyz/client-go v0.0.0-20200116162153-e083ae16abca/go.mod h1:OFxuKCiVR+MYlR2a08FkfaF+IbXkLe0xBetu2LTUuGI=
 kmodules.xyz/constants v0.0.0-20191024095500-cd4313df4aa6 h1:hFv3DzanQJ/bjgahqosmthGLkVgMB2KuQIsltOA02t0=
 kmodules.xyz/constants v0.0.0-20191024095500-cd4313df4aa6/go.mod h1:DbiFk1bJ1KEO94t1SlAn7tzc+Zz95rSXgyUKa2nzPmY=
 kmodules.xyz/crd-schema-fuzz v0.0.0-20191129174258-81f984340891 h1:2W/fqLbAurvupIZL3TEFrlb7DnOIhlOXpNgzgcFFSmA=

--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -31,7 +31,6 @@ import (
 	"stash.appscode.dev/stash/pkg/cli"
 	"stash.appscode.dev/stash/pkg/docker"
 	"stash.appscode.dev/stash/pkg/eventer"
-	stash_rbac "stash.appscode.dev/stash/pkg/rbac"
 	"stash.appscode.dev/stash/pkg/util"
 
 	"github.com/appscode/go/log"
@@ -427,7 +426,7 @@ func (c *Controller) ensureCheckRBAC(namespace string, owner *metav1.OwnerRefere
 		if in.Labels == nil {
 			in.Labels = map[string]string{}
 		}
-		in.Labels["app"] = "stash"
+		in.Labels[apis.LabelApp] = apis.AppLabelStash
 		return in
 	})
 	if err != nil {
@@ -441,16 +440,16 @@ func (c *Controller) ensureCheckRBAC(namespace string, owner *metav1.OwnerRefere
 		if in.Labels == nil {
 			in.Labels = map[string]string{}
 		}
-		in.Labels["app"] = "stash"
+		in.Labels[apis.LabelApp] = apis.AppLabelStash
 
 		in.RoleRef = rbac.RoleRef{
 			APIGroup: rbac.GroupName,
-			Kind:     "ClusterRole",
-			Name:     stash_rbac.StashSidecar,
+			Kind:     apis.KindClusterRole,
+			Name:     apis.StashSidecarClusterRole,
 		}
 		in.Subjects = []rbac.Subject{
 			{
-				Kind:      "ServiceAccount",
+				Kind:      rbac.ServiceAccountKind,
 				Name:      meta.Name,
 				Namespace: meta.Namespace,
 			},

--- a/pkg/backup/prometheus.go
+++ b/pkg/backup/prometheus.go
@@ -20,6 +20,7 @@ import (
 	"regexp"
 	"strings"
 
+	"stash.appscode.dev/stash/apis"
 	api "stash.appscode.dev/stash/apis/stash/v1alpha1"
 
 	ini "gopkg.in/ini.v1"
@@ -43,7 +44,7 @@ func (c *Controller) JobName(resource *api.Restic) string {
 
 func (c *Controller) GroupingKeys(resource *api.Restic) map[string]string {
 	labels := make(map[string]string)
-	labels["app"] = sanitizeLabelValue(c.opt.Workload.Name)
+	labels[apis.LabelApp] = sanitizeLabelValue(c.opt.Workload.Name)
 	labels["kind"] = sanitizeLabelValue(c.opt.Workload.Kind)
 	labels["namespace"] = resource.Namespace
 	labels["stash_config"] = resource.Name

--- a/pkg/controller/backup_configuration.go
+++ b/pkg/controller/backup_configuration.go
@@ -228,7 +228,7 @@ func (c *StashController) EnsureBackupTriggeringCronJob(invoker apis.Invoker) er
 		serviceAccountName = invoker.RuntimeSettings.Pod.ServiceAccountName
 	} else {
 		// ServiceAccount hasn't been specified. so create new one with same name as BackupConfiguration object prefixed with stash-backup.
-		serviceAccountName = meta2.ValidNameWithPrefix(apis.PrefixStashBackup, meta.Name)
+		serviceAccountName = meta.Name
 
 		_, _, err := core_util.CreateOrPatchServiceAccount(c.kubeClient, meta, func(in *core.ServiceAccount) *core.ServiceAccount {
 			core_util.EnsureOwnerReference(&in.ObjectMeta, invoker.OwnerRef)
@@ -295,7 +295,7 @@ func (c *StashController) EnsureBackupTriggeringCronJobDeleted(invoker apis.Invo
 }
 
 func getBackupCronJobName(name string) string {
-	return strings.ReplaceAll(name, ".", "-")
+	return meta2.ValidNameWithPrefix(apis.PrefixStashBackup, strings.ReplaceAll(name, ".", "-"))
 }
 
 func (c *StashController) handleCronJobCreationFailure(ref *core.ObjectReference, err error) error {

--- a/pkg/controller/backup_configuration.go
+++ b/pkg/controller/backup_configuration.go
@@ -295,7 +295,7 @@ func (c *StashController) EnsureBackupTriggeringCronJobDeleted(invoker apis.Invo
 }
 
 func getBackupCronJobName(name string) string {
-	return meta2.ValidNameWithPrefix(apis.PrefixStashBackup, strings.ReplaceAll(name, ".", "-"))
+	return meta2.ValidCronJobNameWithPrefix(apis.PrefixStashBackup, strings.ReplaceAll(name, ".", "-"))
 }
 
 func (c *StashController) handleCronJobCreationFailure(ref *core.ObjectReference, err error) error {

--- a/pkg/controller/backup_session.go
+++ b/pkg/controller/backup_session.go
@@ -167,7 +167,7 @@ func (c *StashController) applyBackupSessionReconciliationLogic(backupSession *a
 
 			// if VolumeSnapshotter driver is used then ensure VolumeSnapshotter job and return
 			if invoker.Driver == api_v1beta1.VolumeSnapshotter {
-				err = c.ensureVolumeSnapshotterJob(invoker, targetInfo, backupSession)
+				err = c.ensureVolumeSnapshotterJob(invoker, targetInfo, backupSession, i)
 				if err != nil {
 					return c.handleBackupJobCreationFailure(invoker, backupSession, err)
 				}
@@ -207,9 +207,13 @@ func (c *StashController) ensureBackupJob(invoker apis.Invoker, targetInfo apis.
 		serviceAccountName = targetInfo.RuntimeSettings.Pod.ServiceAccountName
 	} else {
 		// ServiceAccount hasn't been specified. so create new one.
-		serviceAccountName = jobMeta.Name
-
-		_, _, err := core_util.CreateOrPatchServiceAccount(c.kubeClient, jobMeta, func(in *core.ServiceAccount) *core.ServiceAccount {
+		serviceAccountName = getBackupJobServiceAccountName(invoker.ObjectMeta.Name, strconv.Itoa(index))
+		saMeta := metav1.ObjectMeta{
+			Name:      serviceAccountName,
+			Namespace: invoker.ObjectMeta.Namespace,
+			Labels:    invoker.Labels,
+		}
+		_, _, err := core_util.CreateOrPatchServiceAccount(c.kubeClient, saMeta, func(in *core.ServiceAccount) *core.ServiceAccount {
 			core_util.EnsureOwnerReference(&in.ObjectMeta, invoker.OwnerRef)
 			return in
 		})
@@ -312,26 +316,34 @@ func (c *StashController) ensureBackupJob(invoker apis.Invoker, targetInfo apis.
 	return err
 }
 
-func (c *StashController) ensureVolumeSnapshotterJob(invoker apis.Invoker, targetInfo apis.TargetInfo, backupSession *api_v1beta1.BackupSession) error {
+func (c *StashController) ensureVolumeSnapshotterJob(invoker apis.Invoker, targetInfo apis.TargetInfo, backupSession *api_v1beta1.BackupSession, index int) error {
 	jobMeta := metav1.ObjectMeta{
 		Name:      getVolumeSnapshotterJobName(targetInfo.Target.Ref, backupSession.Name),
 		Namespace: backupSession.Namespace,
 		Labels:    invoker.Labels,
 	}
 
-	//ensure respective RBAC stuffs
-	//Create new ServiceAccount
-	serviceAccountName := jobMeta.Name
-
-	_, _, err := core_util.CreateOrPatchServiceAccount(c.kubeClient, jobMeta, func(in *core.ServiceAccount) *core.ServiceAccount {
-		core_util.EnsureOwnerReference(&in.ObjectMeta, invoker.OwnerRef)
-		return in
-	})
-	if err != nil {
-		return err
+	var serviceAccountName string
+	// Ensure respective RBAC stuffs
+	if targetInfo.RuntimeSettings.Pod != nil && targetInfo.RuntimeSettings.Pod.ServiceAccountName != "" {
+		serviceAccountName = targetInfo.RuntimeSettings.Pod.ServiceAccountName
+	} else {
+		// Create new ServiceAccount
+		serviceAccountName = getVolumeSnapshotterServiceAccountName(invoker.ObjectMeta.Name, strconv.Itoa(index))
+		saMeta := metav1.ObjectMeta{
+			Name:      serviceAccountName,
+			Namespace: invoker.ObjectMeta.Namespace,
+			Labels:    invoker.Labels,
+		}
+		_, _, err := core_util.CreateOrPatchServiceAccount(c.kubeClient, saMeta, func(in *core.ServiceAccount) *core.ServiceAccount {
+			core_util.EnsureOwnerReference(&in.ObjectMeta, invoker.OwnerRef)
+			return in
+		})
+		if err != nil {
+			return err
+		}
 	}
-
-	err = stash_rbac.EnsureVolumeSnapshotterJobRBAC(c.kubeClient, invoker.OwnerRef, invoker.ObjectMeta.Namespace, serviceAccountName, invoker.Labels)
+	err := stash_rbac.EnsureVolumeSnapshotterJobRBAC(c.kubeClient, invoker.OwnerRef, invoker.ObjectMeta.Namespace, serviceAccountName, invoker.Labels)
 	if err != nil {
 		return err
 	}
@@ -549,10 +561,18 @@ func getBackupJobName(backupSession *api_v1beta1.BackupSession, index string) st
 	return meta.ValidNameWithPefixNSuffix(apis.PrefixStashBackup, strings.ReplaceAll(backupSession.Name, ".", "-"), index)
 }
 
+func getBackupJobServiceAccountName(invokerName, index string) string {
+	return meta.ValidNameWithPefixNSuffix(apis.PrefixStashBackup, strings.ReplaceAll(invokerName, ".", "-"), index)
+}
+
 func getVolumeSnapshotterJobName(targetRef api_v1beta1.TargetRef, name string) string {
 	parts := strings.Split(name, "-")
 	suffix := parts[len(parts)-1]
 	return meta.ValidNameWithPrefix(apis.PrefixStashVolumeSnapshot, fmt.Sprintf("%s-%s-%s", util.ResourceKindShortForm(targetRef.Kind), targetRef.Name, suffix))
+}
+
+func getVolumeSnapshotterServiceAccountName(invokerName, index string) string {
+	return meta.ValidNameWithPefixNSuffix(apis.PrefixStashVolumeSnapshot, strings.ReplaceAll(invokerName, ".", "-"), index)
 }
 
 // cleanupBackupHistory deletes old BackupSessions and theirs associate resources according to BackupHistoryLimit

--- a/pkg/controller/restics.go
+++ b/pkg/controller/restics.go
@@ -203,7 +203,7 @@ func (c *StashController) EnsureScaledownCronJob(restic *api.Restic) error {
 		if in.Spec.JobTemplate.Labels == nil {
 			in.Spec.JobTemplate.Labels = map[string]string{}
 		}
-		in.Spec.JobTemplate.Labels["app"] = apis.AppLabelStash
+		in.Spec.JobTemplate.Labels[apis.LabelApp] = apis.AppLabelStash
 		in.Spec.JobTemplate.Labels[apis.AnnotationRestic] = restic.Name
 		in.Spec.JobTemplate.Labels[apis.AnnotationOperation] = apis.OperationScaleDown
 

--- a/pkg/controller/restore_session.go
+++ b/pkg/controller/restore_session.go
@@ -242,7 +242,7 @@ func (c *StashController) ensureRestoreJob(restoreSession *api_v1beta1.RestoreSe
 		serviceAccountName = restoreSession.Spec.RuntimeSettings.Pod.ServiceAccountName
 	} else {
 		// ServiceAccount hasn't been specified. so create new one with same name as RestoreSession object.
-		serviceAccountName = getRestoreJobServiceAccountName(jobMeta.Name)
+		serviceAccountName = getRestoreJobServiceAccountName(restoreSession.Name)
 		saMeta := metav1.ObjectMeta{
 			Name:      serviceAccountName,
 			Namespace: restoreSession.Namespace,
@@ -482,7 +482,7 @@ func (c *StashController) ensureVolumeRestorerJob(restoreSession *api_v1beta1.Re
 		// ServiceAccount has been specified, so use it.
 		serviceAccountName = restoreSession.Spec.RuntimeSettings.Pod.ServiceAccountName
 	} else {
-		serviceAccountName = getVolumeRestorerServiceAccountName(jobMeta.Name)
+		serviceAccountName = getVolumeRestorerServiceAccountName(restoreSession.Name)
 		saMeta := metav1.ObjectMeta{
 			Name:      serviceAccountName,
 			Namespace: restoreSession.Namespace,

--- a/pkg/rbac/backup_job.go
+++ b/pkg/rbac/backup_job.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"strings"
 
+	"stash.appscode.dev/stash/apis"
 	api_v1alpha1 "stash.appscode.dev/stash/apis/stash/v1alpha1"
 	api_v1beta1 "stash.appscode.dev/stash/apis/stash/v1beta1"
 
@@ -31,10 +32,6 @@ import (
 	core_util "kmodules.xyz/client-go/core/v1"
 	rbac_util "kmodules.xyz/client-go/rbac/v1"
 	appCatalog "kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1"
-)
-
-const (
-	StashBackupJob = "stash-backup-job"
 )
 
 func EnsureBackupJobRBAC(kubeClient kubernetes.Interface, owner *metav1.OwnerReference, namespace, sa string, psps []string, labels map[string]string) error {
@@ -56,7 +53,7 @@ func EnsureBackupJobRBAC(kubeClient kubernetes.Interface, owner *metav1.OwnerRef
 func ensureBackupJobClusterRole(kubeClient kubernetes.Interface, psps []string, labels map[string]string) error {
 
 	meta := metav1.ObjectMeta{
-		Name:   StashBackupJob,
+		Name:   apis.StashBackupJobClusterRole,
 		Labels: labels,
 	}
 	_, _, err := rbac_util.CreateOrPatchClusterRole(kubeClient, meta, func(in *rbac.ClusterRole) *rbac.ClusterRole {
@@ -116,12 +113,12 @@ func ensureBackupJobRoleBinding(kubeClient kubernetes.Interface, owner *metav1.O
 
 		in.RoleRef = rbac.RoleRef{
 			APIGroup: rbac.GroupName,
-			Kind:     "ClusterRole",
-			Name:     StashBackupJob,
+			Kind:     apis.KindClusterRole,
+			Name:     apis.StashBackupJobClusterRole,
 		}
 		in.Subjects = []rbac.Subject{
 			{
-				Kind:      "ServiceAccount",
+				Kind:      rbac.ServiceAccountKind,
 				Name:      sa,
 				Namespace: namespace,
 			},
@@ -132,5 +129,5 @@ func ensureBackupJobRoleBinding(kubeClient kubernetes.Interface, owner *metav1.O
 }
 
 func getBackupJobRoleBindingName(name string) string {
-	return fmt.Sprintf("%s-%s", StashBackupJob, strings.ReplaceAll(name, ".", "-"))
+	return fmt.Sprintf("%s-%s", apis.StashBackupJobClusterRole, strings.ReplaceAll(name, ".", "-"))
 }

--- a/pkg/rbac/backup_job.go
+++ b/pkg/rbac/backup_job.go
@@ -17,7 +17,6 @@ limitations under the License.
 package rbac
 
 import (
-	"fmt"
 	"strings"
 
 	"stash.appscode.dev/stash/apis"
@@ -104,7 +103,7 @@ func ensureBackupJobClusterRole(kubeClient kubernetes.Interface, psps []string, 
 func ensureBackupJobRoleBinding(kubeClient kubernetes.Interface, owner *metav1.OwnerReference, namespace, sa string, labels map[string]string) error {
 
 	meta := metav1.ObjectMeta{
-		Name:      getBackupJobRoleBindingName(owner.Name),
+		Name:      getBackupJobRoleBindingName(sa),
 		Namespace: namespace,
 		Labels:    labels,
 	}
@@ -129,5 +128,7 @@ func ensureBackupJobRoleBinding(kubeClient kubernetes.Interface, owner *metav1.O
 }
 
 func getBackupJobRoleBindingName(name string) string {
-	return fmt.Sprintf("%s-%s", apis.StashBackupJobClusterRole, strings.ReplaceAll(name, ".", "-"))
+	// Create RoleBinding with name same as the ServiceAccount name.
+	// The ServiceAccount already has Stash specific prefix in it's name.
+	return strings.ReplaceAll(name, ".", "-")
 }

--- a/pkg/rbac/cronjob.go
+++ b/pkg/rbac/cronjob.go
@@ -17,7 +17,7 @@ limitations under the License.
 package rbac
 
 import (
-	"fmt"
+	"strings"
 
 	"stash.appscode.dev/stash/apis"
 	api_v1beta1 "stash.appscode.dev/stash/apis/stash/v1beta1"
@@ -105,7 +105,7 @@ func ensureCronJobClusterRole(kubeClient kubernetes.Interface, psps []string, la
 
 func ensureCronJobRoleBinding(kubeClient kubernetes.Interface, owner *metav1.OwnerReference, namespace, sa string, labels map[string]string) error {
 	meta := metav1.ObjectMeta{
-		Name:      fmt.Sprintf("%s-%s", apis.StashCronJobClusterRole, owner.Name),
+		Name:      getCronJobRoleBindingName(sa),
 		Namespace: namespace,
 		Labels:    labels,
 	}
@@ -132,4 +132,10 @@ func ensureCronJobRoleBinding(kubeClient kubernetes.Interface, owner *metav1.Own
 		return err
 	}
 	return nil
+}
+
+func getCronJobRoleBindingName(name string) string {
+	// Create RoleBinding with name same as the ServiceAccount name.
+	// The ServiceAccount already has Stash specific prefix in it's name.
+	return strings.ReplaceAll(name, ".", "-")
 }

--- a/pkg/rbac/cronjob.go
+++ b/pkg/rbac/cronjob.go
@@ -19,6 +19,7 @@ package rbac
 import (
 	"fmt"
 
+	"stash.appscode.dev/stash/apis"
 	api_v1beta1 "stash.appscode.dev/stash/apis/stash/v1beta1"
 
 	apps "k8s.io/api/apps/v1"
@@ -29,10 +30,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	core_util "kmodules.xyz/client-go/core/v1"
 	rbac_util "kmodules.xyz/client-go/rbac/v1"
-)
-
-const (
-	StashCronJob = "stash-cron-job"
 )
 
 func EnsureCronJobRBAC(kubeClient kubernetes.Interface, owner *metav1.OwnerReference, namespace, sa string, psps []string, labels map[string]string) error {
@@ -48,7 +45,7 @@ func EnsureCronJobRBAC(kubeClient kubernetes.Interface, owner *metav1.OwnerRefer
 
 func ensureCronJobClusterRole(kubeClient kubernetes.Interface, psps []string, labels map[string]string) error {
 	meta := metav1.ObjectMeta{
-		Name:   StashCronJob,
+		Name:   apis.StashCronJobClusterRole,
 		Labels: labels,
 	}
 	_, _, err := rbac_util.CreateOrPatchClusterRole(kubeClient, meta, func(in *rbac.ClusterRole) *rbac.ClusterRole {
@@ -108,7 +105,7 @@ func ensureCronJobClusterRole(kubeClient kubernetes.Interface, psps []string, la
 
 func ensureCronJobRoleBinding(kubeClient kubernetes.Interface, owner *metav1.OwnerReference, namespace, sa string, labels map[string]string) error {
 	meta := metav1.ObjectMeta{
-		Name:      fmt.Sprintf("%s-%s", StashCronJob, owner.Name),
+		Name:      fmt.Sprintf("%s-%s", apis.StashCronJobClusterRole, owner.Name),
 		Namespace: namespace,
 		Labels:    labels,
 	}
@@ -119,8 +116,8 @@ func ensureCronJobRoleBinding(kubeClient kubernetes.Interface, owner *metav1.Own
 
 		in.RoleRef = rbac.RoleRef{
 			APIGroup: rbac.GroupName,
-			Kind:     KindClusterRole,
-			Name:     StashCronJob,
+			Kind:     apis.KindClusterRole,
+			Name:     apis.StashCronJobClusterRole,
 		}
 		in.Subjects = []rbac.Subject{
 			{

--- a/pkg/rbac/init_container.go
+++ b/pkg/rbac/init_container.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"strings"
 
+	"stash.appscode.dev/stash/apis"
 	api "stash.appscode.dev/stash/apis/stash/v1alpha1"
 	api_v1beta1 "stash.appscode.dev/stash/apis/stash/v1beta1"
 
@@ -52,7 +53,7 @@ func EnsureRestoreInitContainerRBAC(kubeClient kubernetes.Interface, owner *meta
 
 func ensureRestoreInitContainerClusterRole(kubeClient kubernetes.Interface, labels map[string]string) error {
 	meta := metav1.ObjectMeta{
-		Name:   StashRestoreInitContainer,
+		Name:   apis.StashRestoreInitContainerClusterRole,
 		Labels: labels,
 	}
 	_, _, err := rbac_util.CreateOrPatchClusterRole(kubeClient, meta, func(in *rbac.ClusterRole) *rbac.ClusterRole {
@@ -109,8 +110,8 @@ func ensureRestoreInitContainerRoleBinding(kubeClient kubernetes.Interface, owne
 
 		in.RoleRef = rbac.RoleRef{
 			APIGroup: rbac.GroupName,
-			Kind:     "ClusterRole",
-			Name:     StashRestoreInitContainer,
+			Kind:     apis.KindClusterRole,
+			Name:     apis.StashRestoreInitContainerClusterRole,
 		}
 		in.Subjects = []rbac.Subject{
 			{
@@ -125,7 +126,7 @@ func ensureRestoreInitContainerRoleBinding(kubeClient kubernetes.Interface, owne
 }
 
 func getRestoreInitContainerRoleBindingName(kind string) string {
-	return fmt.Sprintf("%s-%s", StashRestoreInitContainer, strings.ToLower(kind))
+	return fmt.Sprintf("%s-%s", apis.StashRestoreInitContainerClusterRole, strings.ToLower(kind))
 }
 
 func ensureRestoreInitContainerRoleBindingDeleted(kubeClient kubernetes.Interface, w *wapi.Workload) error {

--- a/pkg/rbac/jobs.go
+++ b/pkg/rbac/jobs.go
@@ -38,10 +38,7 @@ import (
 )
 
 const (
-	ScaledownJobRole          = "stash-scaledownjob"
-	StashRestoreInitContainer = "stash-restore-init-container"
-	KindRole                  = "Role"
-	KindClusterRole           = "ClusterRole"
+	ScaledownJobRole = "stash-scaledownjob"
 )
 
 // use scaledownjob-role, service-account and role-binding name same as job name
@@ -58,7 +55,7 @@ func EnsureScaledownJobRBAC(kubeClient kubernetes.Interface, owner *metav1.Owner
 		if in.Labels == nil {
 			in.Labels = map[string]string{}
 		}
-		in.Labels["app"] = apis.AppLabelStash
+		in.Labels[apis.LabelApp] = apis.AppLabelStash
 
 		in.Rules = []rbac.PolicyRule{
 			{
@@ -98,7 +95,7 @@ func EnsureScaledownJobRBAC(kubeClient kubernetes.Interface, owner *metav1.Owner
 		if in.Labels == nil {
 			in.Labels = map[string]string{}
 		}
-		in.Labels["app"] = apis.AppLabelStash
+		in.Labels[apis.LabelApp] = apis.AppLabelStash
 		return in
 	})
 	if err != nil {
@@ -112,16 +109,16 @@ func EnsureScaledownJobRBAC(kubeClient kubernetes.Interface, owner *metav1.Owner
 		if in.Labels == nil {
 			in.Labels = map[string]string{}
 		}
-		in.Labels["app"] = apis.AppLabelStash
+		in.Labels[apis.LabelApp] = apis.AppLabelStash
 
 		in.RoleRef = rbac.RoleRef{
 			APIGroup: rbac.GroupName,
-			Kind:     "Role",
+			Kind:     apis.KindRole,
 			Name:     ScaledownJobRole,
 		}
 		in.Subjects = []rbac.Subject{
 			{
-				Kind:      "ServiceAccount",
+				Kind:      rbac.ServiceAccountKind,
 				Name:      meta.Name,
 				Namespace: meta.Namespace,
 			},
@@ -157,16 +154,16 @@ func EnsureRecoveryRBAC(kubeClient kubernetes.Interface, owner *metav1.OwnerRefe
 		if in.Labels == nil {
 			in.Labels = map[string]string{}
 		}
-		in.Labels["app"] = apis.AppLabelStash
+		in.Labels[apis.LabelApp] = apis.AppLabelStash
 
 		in.RoleRef = rbac.RoleRef{
 			APIGroup: rbac.GroupName,
-			Kind:     "ClusterRole",
-			Name:     StashSidecar,
+			Kind:     apis.KindClusterRole,
+			Name:     apis.StashSidecarClusterRole,
 		}
 		in.Subjects = []rbac.Subject{
 			{
-				Kind:      "ServiceAccount",
+				Kind:      rbac.ServiceAccountKind,
 				Name:      meta.Name,
 				Namespace: meta.Namespace,
 			},
@@ -199,17 +196,17 @@ func EnsureRepoReaderRBAC(kubeClient kubernetes.Interface, stashClient stash_cs.
 		if in.Labels == nil {
 			in.Labels = map[string]string{}
 		}
-		in.Labels["app"] = apis.AppLabelStash
+		in.Labels[apis.LabelApp] = apis.AppLabelStash
 
 		in.RoleRef = rbac.RoleRef{
 			APIGroup: rbac.GroupName,
-			Kind:     "Role",
+			Kind:     apis.KindRole,
 			Name:     getRepoReaderRoleName(rec.Spec.Repository.Name),
 		}
 
 		in.Subjects = []rbac.Subject{
 			{
-				Kind:      "ServiceAccount",
+				Kind:      rbac.ServiceAccountKind,
 				Name:      owner.Name,
 				Namespace: rec.Namespace,
 			},
@@ -232,7 +229,7 @@ func ensureRepoReaderRole(kubeClient kubernetes.Interface, repo *api_v1alpha1.Re
 		if in.Labels == nil {
 			in.Labels = map[string]string{}
 		}
-		in.Labels["app"] = apis.AppLabelStash
+		in.Labels[apis.LabelApp] = apis.AppLabelStash
 
 		in.Rules = []rbac.PolicyRule{
 			{

--- a/pkg/rbac/restore_job.go
+++ b/pkg/rbac/restore_job.go
@@ -19,6 +19,7 @@ package rbac
 import (
 	"fmt"
 
+	"stash.appscode.dev/stash/apis"
 	api_v1alpha1 "stash.appscode.dev/stash/apis/stash/v1alpha1"
 	api_v1beta1 "stash.appscode.dev/stash/apis/stash/v1beta1"
 
@@ -30,10 +31,6 @@ import (
 	core_util "kmodules.xyz/client-go/core/v1"
 	rbac_util "kmodules.xyz/client-go/rbac/v1"
 	appCatalog "kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1"
-)
-
-const (
-	StashRestoreJob = "stash-restore-job"
 )
 
 func EnsureRestoreJobRBAC(kubeClient kubernetes.Interface, owner *metav1.OwnerReference, namespace, sa string, psps []string, labels map[string]string) error {
@@ -55,7 +52,7 @@ func EnsureRestoreJobRBAC(kubeClient kubernetes.Interface, owner *metav1.OwnerRe
 func ensureRestoreJobClusterRole(kubeClient kubernetes.Interface, psps []string, labels map[string]string) error {
 
 	meta := metav1.ObjectMeta{
-		Name:   StashRestoreJob,
+		Name:   apis.StashRestoreJobClusterRole,
 		Labels: labels,
 	}
 	_, _, err := rbac_util.CreateOrPatchClusterRole(kubeClient, meta, func(in *rbac.ClusterRole) *rbac.ClusterRole {
@@ -117,12 +114,12 @@ func ensureRestoreJobRoleBinding(kubeClient kubernetes.Interface, resource *meta
 
 		in.RoleRef = rbac.RoleRef{
 			APIGroup: rbac.GroupName,
-			Kind:     "ClusterRole",
-			Name:     StashRestoreJob,
+			Kind:     apis.KindClusterRole,
+			Name:     apis.StashRestoreJobClusterRole,
 		}
 		in.Subjects = []rbac.Subject{
 			{
-				Kind:      "ServiceAccount",
+				Kind:      rbac.ServiceAccountKind,
 				Name:      sa,
 				Namespace: namespace,
 			},
@@ -133,5 +130,5 @@ func ensureRestoreJobRoleBinding(kubeClient kubernetes.Interface, resource *meta
 }
 
 func getRestoreJobRoleBindingName(name string) string {
-	return fmt.Sprintf("%s-%s", StashRestoreJob, name)
+	return fmt.Sprintf("%s-%s", apis.StashRestoreJobClusterRole, name)
 }

--- a/pkg/rbac/restore_job.go
+++ b/pkg/rbac/restore_job.go
@@ -18,6 +18,7 @@ package rbac
 
 import (
 	"fmt"
+	"strings"
 
 	"stash.appscode.dev/stash/apis"
 	api_v1alpha1 "stash.appscode.dev/stash/apis/stash/v1alpha1"
@@ -106,7 +107,7 @@ func ensureRestoreJobRoleBinding(kubeClient kubernetes.Interface, resource *meta
 
 	meta := metav1.ObjectMeta{
 		Namespace: namespace,
-		Name:      getRestoreJobRoleBindingName(resource.Name),
+		Name:      getRestoreJobRoleBindingName(sa),
 		Labels:    labels,
 	}
 	_, _, err := rbac_util.CreateOrPatchRoleBinding(kubeClient, meta, func(in *rbac.RoleBinding) *rbac.RoleBinding {
@@ -130,5 +131,7 @@ func ensureRestoreJobRoleBinding(kubeClient kubernetes.Interface, resource *meta
 }
 
 func getRestoreJobRoleBindingName(name string) string {
-	return fmt.Sprintf("%s-%s", apis.StashRestoreJobClusterRole, name)
+	// Create RoleBinding with name same as the ServiceAccount name.
+	// The ServiceAccount already has Stash specific prefix in it's name.
+	return strings.ReplaceAll(name, ".", "-")
 }

--- a/pkg/rbac/sidecar.go
+++ b/pkg/rbac/sidecar.go
@@ -38,16 +38,12 @@ import (
 	wapi "kmodules.xyz/webhook-runtime/apis/workload/v1"
 )
 
-const (
-	StashSidecar = "stash-sidecar"
-)
-
 func getSidecarRoleBindingName(name string, kind string) string {
-	return fmt.Sprintf("%s-%s-%s", StashSidecar, strings.ToLower(kind), name)
+	return fmt.Sprintf("%s-%s-%s", apis.StashSidecarClusterRole, strings.ToLower(kind), name)
 }
 
 func EnsureSidecarClusterRole(kubeClient kubernetes.Interface) error {
-	meta := metav1.ObjectMeta{Name: StashSidecar}
+	meta := metav1.ObjectMeta{Name: apis.StashSidecarClusterRole}
 	_, _, err := rbac_util.CreateOrPatchClusterRole(kubeClient, meta, func(in *rbac.ClusterRole) *rbac.ClusterRole {
 		if in.Labels == nil {
 			in.Labels = map[string]string{}
@@ -136,8 +132,8 @@ func EnsureSidecarRoleBinding(kubeClient kubernetes.Interface, owner *metav1.Own
 
 		in.RoleRef = rbac.RoleRef{
 			APIGroup: rbac.GroupName,
-			Kind:     "ClusterRole",
-			Name:     StashSidecar,
+			Kind:     apis.KindClusterRole,
+			Name:     apis.StashSidecarClusterRole,
 		}
 		in.Subjects = []rbac.Subject{
 			{

--- a/pkg/rbac/sidecar.go
+++ b/pkg/rbac/sidecar.go
@@ -17,7 +17,6 @@ limitations under the License.
 package rbac
 
 import (
-	"fmt"
 	"strings"
 
 	"stash.appscode.dev/stash/apis"
@@ -34,12 +33,13 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/pkg/apis/batch"
 	core_util "kmodules.xyz/client-go/core/v1"
+	meta_util "kmodules.xyz/client-go/meta"
 	rbac_util "kmodules.xyz/client-go/rbac/v1"
 	wapi "kmodules.xyz/webhook-runtime/apis/workload/v1"
 )
 
 func getSidecarRoleBindingName(name string, kind string) string {
-	return fmt.Sprintf("%s-%s-%s", apis.StashSidecarClusterRole, strings.ToLower(kind), name)
+	return meta_util.ValidNameWithPefixNSuffix(apis.StashSidecarClusterRole, strings.ToLower(kind), name)
 }
 
 func EnsureSidecarClusterRole(kubeClient kubernetes.Interface) error {

--- a/pkg/rbac/volume_snapshot.go
+++ b/pkg/rbac/volume_snapshot.go
@@ -19,6 +19,7 @@ package rbac
 import (
 	"fmt"
 
+	"stash.appscode.dev/stash/apis"
 	api_v1alpha1 "stash.appscode.dev/stash/apis/stash/v1alpha1"
 	api_v1beta1 "stash.appscode.dev/stash/apis/stash/v1beta1"
 
@@ -31,12 +32,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	core_util "kmodules.xyz/client-go/core/v1"
 	rbac_util "kmodules.xyz/client-go/rbac/v1"
-)
-
-const (
-	StashVolumeSnapshotterJob      = "stash-volumesnapshotter-job"
-	StashVolumeSnapshotRestorerJob = "stash-volumesnapshot-restorer-job"
-	StashStorageClassReader        = "stash-storage-class-reader"
 )
 
 func EnsureVolumeSnapshotterJobRBAC(kubeClient kubernetes.Interface, owner *metav1.OwnerReference, namespace, sa string, labels map[string]string) error {
@@ -58,7 +53,7 @@ func EnsureVolumeSnapshotterJobRBAC(kubeClient kubernetes.Interface, owner *meta
 func ensureVolumeSnapshotterJobClusterRole(kubeClient kubernetes.Interface, labels map[string]string) error {
 
 	meta := metav1.ObjectMeta{
-		Name:   StashVolumeSnapshotterJob,
+		Name:   apis.StashVolumeSnapshotterClusterRole,
 		Labels: labels,
 	}
 	_, _, err := rbac_util.CreateOrPatchClusterRole(kubeClient, meta, func(in *rbac.ClusterRole) *rbac.ClusterRole {
@@ -127,8 +122,8 @@ func ensureVolumeSnapshotterJobRoleBinding(kubeClient kubernetes.Interface, reso
 
 		in.RoleRef = rbac.RoleRef{
 			APIGroup: rbac.GroupName,
-			Kind:     KindClusterRole,
-			Name:     StashVolumeSnapshotterJob,
+			Kind:     apis.KindClusterRole,
+			Name:     apis.StashVolumeSnapshotterClusterRole,
 		}
 		in.Subjects = []rbac.Subject{
 			{
@@ -143,7 +138,7 @@ func ensureVolumeSnapshotterJobRoleBinding(kubeClient kubernetes.Interface, reso
 }
 
 func getVolumesnapshotterJobRoleBindingName(name string) string {
-	return fmt.Sprintf("%s-%s", StashVolumeSnapshotterJob, name)
+	return fmt.Sprintf("%s-%s", apis.StashVolumeSnapshotterClusterRole, name)
 }
 
 func EnsureVolumeSnapshotRestorerJobRBAC(kubeClient kubernetes.Interface, owner *metav1.OwnerReference, namespace, sa string, labels map[string]string) error {
@@ -177,7 +172,7 @@ func EnsureVolumeSnapshotRestorerJobRBAC(kubeClient kubernetes.Interface, owner 
 func ensureVolumeSnapshotRestorerJobClusterRole(kubeClient kubernetes.Interface, labels map[string]string) error {
 
 	meta := metav1.ObjectMeta{
-		Name:   StashVolumeSnapshotRestorerJob,
+		Name:   apis.StashVolumeSnapshotRestorerClusterRole,
 		Labels: labels,
 	}
 	_, _, err := rbac_util.CreateOrPatchClusterRole(kubeClient, meta, func(in *rbac.ClusterRole) *rbac.ClusterRole {
@@ -227,8 +222,8 @@ func ensureVolumeSnapshotRestorerJobRoleBinding(kubeClient kubernetes.Interface,
 
 		in.RoleRef = rbac.RoleRef{
 			APIGroup: rbac.GroupName,
-			Kind:     "ClusterRole",
-			Name:     StashVolumeSnapshotRestorerJob,
+			Kind:     apis.KindClusterRole,
+			Name:     apis.StashVolumeSnapshotRestorerClusterRole,
 		}
 		in.Subjects = []rbac.Subject{
 			{
@@ -243,13 +238,13 @@ func ensureVolumeSnapshotRestorerJobRoleBinding(kubeClient kubernetes.Interface,
 }
 
 func getVolumeSnapshotRestorerJobRoleBindingName(name string) string {
-	return fmt.Sprintf("%s-%s", StashVolumeSnapshotRestorerJob, name)
+	return fmt.Sprintf("%s-%s", apis.StashVolumeSnapshotRestorerClusterRole, name)
 }
 
 func ensureStorageReaderClassClusterRole(kubeClient kubernetes.Interface, labels map[string]string) error {
 
 	meta := metav1.ObjectMeta{
-		Name:   StashStorageClassReader,
+		Name:   apis.StashStorageClassReaderClusterRole,
 		Labels: labels,
 	}
 	_, _, err := rbac_util.CreateOrPatchClusterRole(kubeClient, meta, func(in *rbac.ClusterRole) *rbac.ClusterRole {
@@ -284,8 +279,8 @@ func ensureStorageClassReaderClusterRoleBinding(kubeClient kubernetes.Interface,
 
 		in.RoleRef = rbac.RoleRef{
 			APIGroup: rbac.GroupName,
-			Kind:     "ClusterRole",
-			Name:     StashStorageClassReader,
+			Kind:     apis.KindClusterRole,
+			Name:     apis.StashStorageClassReaderClusterRole,
 		}
 		in.Subjects = []rbac.Subject{
 			{
@@ -300,5 +295,5 @@ func ensureStorageClassReaderClusterRoleBinding(kubeClient kubernetes.Interface,
 }
 
 func getStorageClassReaderClusterRoleBindingName(name string) string {
-	return fmt.Sprintf("%s-%s", StashStorageClassReader, name)
+	return fmt.Sprintf("%s-%s", apis.StashStorageClassReaderClusterRole, name)
 }

--- a/test/e2e/auto-backup/deployment.go
+++ b/test/e2e/auto-backup/deployment.go
@@ -66,7 +66,7 @@ var _ = Describe("Auto-Backup", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				// Deploy a Deployment
-				deployment, err := f.DeployDeployment(framework.SourceDaemonSet, int32(1), framework.SourceVolume)
+				deployment, err := f.DeployDeployment(framework.SourceDeployment, int32(1), framework.SourceVolume)
 				Expect(err).NotTo(HaveOccurred())
 
 				// Generate Sample Data

--- a/test/e2e/framework/backup_configuration.go
+++ b/test/e2e/framework/backup_configuration.go
@@ -17,8 +17,10 @@ limitations under the License.
 package framework
 
 import (
+	"strings"
 	"time"
 
+	"stash.appscode.dev/stash/apis"
 	"stash.appscode.dev/stash/apis/stash/v1alpha1"
 	"stash.appscode.dev/stash/apis/stash/v1beta1"
 
@@ -27,6 +29,7 @@ import (
 	core "k8s.io/api/core/v1"
 	kerr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	meta_util "kmodules.xyz/client-go/meta"
 )
 
 func (fi *Invocation) GetBackupConfiguration(repoName string, transformFuncs ...func(bc *v1beta1.BackupConfiguration)) *v1beta1.BackupConfiguration {
@@ -76,7 +79,7 @@ func (fi *Invocation) DeleteBackupConfiguration(backupCfg v1beta1.BackupConfigur
 func (f *Framework) EventuallyCronJobCreated(meta metav1.ObjectMeta) GomegaAsyncAssertion {
 	return Eventually(
 		func() bool {
-			_, err := f.KubeClient.BatchV1beta1().CronJobs(meta.Namespace).Get(meta.Name, metav1.GetOptions{})
+			_, err := f.KubeClient.BatchV1beta1().CronJobs(meta.Namespace).Get(getBackupCronJobName(meta), metav1.GetOptions{})
 			if err == nil && !kerr.IsNotFound(err) {
 				return true
 			}
@@ -90,7 +93,7 @@ func (f *Framework) EventuallyCronJobCreated(meta metav1.ObjectMeta) GomegaAsync
 func (f *Framework) EventuallyCronJobSuspended(meta metav1.ObjectMeta) GomegaAsyncAssertion {
 	return Eventually(
 		func() bool {
-			cronJob, err := f.KubeClient.BatchV1beta1().CronJobs(meta.Namespace).Get(meta.Name, metav1.GetOptions{})
+			cronJob, err := f.KubeClient.BatchV1beta1().CronJobs(meta.Namespace).Get(getBackupCronJobName(meta), metav1.GetOptions{})
 			if err != nil {
 				return false
 			}
@@ -104,7 +107,7 @@ func (f *Framework) EventuallyCronJobSuspended(meta metav1.ObjectMeta) GomegaAsy
 func (f *Framework) EventuallyCronJobResumed(meta metav1.ObjectMeta) GomegaAsyncAssertion {
 	return Eventually(
 		func() bool {
-			cronJob, err := f.KubeClient.BatchV1beta1().CronJobs(meta.Namespace).Get(meta.Name, metav1.GetOptions{})
+			cronJob, err := f.KubeClient.BatchV1beta1().CronJobs(meta.Namespace).Get(getBackupCronJobName(meta), metav1.GetOptions{})
 			if err != nil {
 				return false
 			}
@@ -127,4 +130,8 @@ func (f *Framework) EventuallyBackupConfigurationCreated(meta metav1.ObjectMeta)
 		time.Minute*2,
 		time.Second*5,
 	)
+}
+
+func getBackupCronJobName(objMeta metav1.ObjectMeta) string {
+	return meta_util.ValidNameWithPrefix(apis.PrefixStashBackup, strings.ReplaceAll(objMeta.Name, ".", "-"))
 }

--- a/test/e2e/framework/backup_configuration.go
+++ b/test/e2e/framework/backup_configuration.go
@@ -133,5 +133,5 @@ func (f *Framework) EventuallyBackupConfigurationCreated(meta metav1.ObjectMeta)
 }
 
 func getBackupCronJobName(objMeta metav1.ObjectMeta) string {
-	return meta_util.ValidNameWithPrefix(apis.PrefixStashBackup, strings.ReplaceAll(objMeta.Name, ".", "-"))
+	return meta_util.ValidCronJobNameWithPrefix(apis.PrefixStashBackup, strings.ReplaceAll(objMeta.Name, ".", "-"))
 }

--- a/test/e2e/framework/mysql.go
+++ b/test/e2e/framework/mysql.go
@@ -444,7 +444,7 @@ func (f *Framework) EnsureMySQLAddonDeleted() error {
 	}
 
 	// delete MySQL restore Task
-	err = f.StashClient.StashV1beta1().Functions().Delete(MySQLRestoreTask, deleteInBackground())
+	err = f.StashClient.StashV1beta1().Tasks().Delete(MySQLRestoreTask, deleteInBackground())
 	if err != nil {
 		return err
 	}

--- a/vendor/kmodules.xyz/client-go/core/v1/node.go
+++ b/vendor/kmodules.xyz/client-go/core/v1/node.go
@@ -138,23 +138,23 @@ func Topology(kc kubernetes.Interface) (regions map[string][]string, instances m
 
 		annotations := m.GetAnnotations()
 
-		os, _ := meta_util.GetStringVaultForKeys(annotations, "kubernetes.io/os", "beta.kubernetes.io/os")
+		os, _ := meta_util.GetStringValueForKeys(annotations, "kubernetes.io/os", "beta.kubernetes.io/os")
 		if os != "linux" {
 			return nil
 		}
-		arch, _ := meta_util.GetStringVaultForKeys(annotations, "kubernetes.io/arch", "beta.kubernetes.io/arch")
+		arch, _ := meta_util.GetStringValueForKeys(annotations, "kubernetes.io/arch", "beta.kubernetes.io/arch")
 		if arch != "amd64" {
 			return nil
 		}
 
-		region, _ := meta_util.GetStringVaultForKeys(annotations, "topology.kubernetes.io/region", "failure-domain.beta.kubernetes.io/region")
-		zone, _ := meta_util.GetStringVaultForKeys(annotations, "topology.kubernetes.io/zone", "failure-domain.beta.kubernetes.io/zone")
+		region, _ := meta_util.GetStringValueForKeys(annotations, "topology.kubernetes.io/region", "failure-domain.beta.kubernetes.io/region")
+		zone, _ := meta_util.GetStringValueForKeys(annotations, "topology.kubernetes.io/zone", "failure-domain.beta.kubernetes.io/zone")
 		if _, ok := mapRegion[region]; !ok {
 			mapRegion[region] = sets.NewString()
 		}
 		mapRegion[region].Insert(zone)
 
-		instance, _ := meta_util.GetStringVaultForKeys(annotations, "node.kubernetes.io/instance-type", "beta.kubernetes.io/instance-type")
+		instance, _ := meta_util.GetStringValueForKeys(annotations, "node.kubernetes.io/instance-type", "beta.kubernetes.io/instance-type")
 		if n, ok := instances[instance]; ok {
 			instances[instance] = n + 1
 		} else {

--- a/vendor/kmodules.xyz/client-go/discovery/lib.go
+++ b/vendor/kmodules.xyz/client-go/discovery/lib.go
@@ -110,8 +110,11 @@ var err62649_K1_10 = &KnownBug{URL: "https://github.com/kubernetes/kubernetes/pu
 var err83778_K1_16 = &KnownBug{URL: "https://github.com/kubernetes/kubernetes/pull/83787", Fix: "upgrade to Kubernetes 1.16.2 or later."}
 
 var (
-	DefaultConstraint                     = ">= 1.11.0"
-	DefaultBlackListedVersions            map[string]error
+	DefaultConstraint          = ">= 1.11.0"
+	DefaultBlackListedVersions = map[string]error{
+		"1.16.0": err83778_K1_16,
+		"1.16.1": err83778_K1_16,
+	}
 	DefaultBlackListedMultiMasterVersions = map[string]error{
 		"1.9.0":  err62649_K1_9,
 		"1.9.1":  err62649_K1_9,
@@ -123,8 +126,6 @@ var (
 		"1.9.7":  err62649_K1_9,
 		"1.10.0": err62649_K1_10,
 		"1.10.1": err62649_K1_10,
-		"1.16.0": err83778_K1_16,
-		"1.16.1": err83778_K1_16,
 	}
 )
 

--- a/vendor/kmodules.xyz/client-go/meta/annotations.go
+++ b/vendor/kmodules.xyz/client-go/meta/annotations.go
@@ -175,7 +175,7 @@ func ParseFor(key string, fn ParserFunc) GetFunc {
 	}
 }
 
-func GetStringVaultForKeys(m map[string]string, key string, alts ...string) (string, error) {
+func GetStringValueForKeys(m map[string]string, key string, alts ...string) (string, error) {
 	if m == nil {
 		return "", kutil.ErrNotFound
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -996,7 +996,7 @@ k8s.io/utils/net
 k8s.io/utils/path
 k8s.io/utils/pointer
 k8s.io/utils/trace
-# kmodules.xyz/client-go v0.0.0-20200105092743-4b797c0c0802
+# kmodules.xyz/client-go v0.0.0-20200116162153-e083ae16abca
 kmodules.xyz/client-go
 kmodules.xyz/client-go/admissionregistration/v1beta1
 kmodules.xyz/client-go/apiextensions/v1beta1


### PR DESCRIPTION
- Use ServiceAccount meta same as the owning object
- Use Stash specific prefix in owning object name to avoid conflict with other tools.