### PR TITLE
Prepare for release v0.10.0-rc.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	kmodules.xyz/openshift v0.0.0-20200522123204-ce4abf5433c8
 	kmodules.xyz/prober v0.0.0-20200521101241-adf06150535c
 	kmodules.xyz/webhook-runtime v0.0.0-20200522123600-ca70a7e28ed0
-	stash.appscode.dev/apimachinery v0.10.0-beta.1.0.20200817055640-692909fead2f
+	stash.appscode.dev/apimachinery v0.10.0-rc.0
 )
 
 replace bitbucket.org/ww/goautoneg => gomodules.xyz/goautoneg v0.0.0-20120707110453-a547fc61f48d

--- a/go.sum
+++ b/go.sum
@@ -985,8 +985,6 @@ kmodules.xyz/client-go v0.0.0-20200521005126-35ce6bd4ed46/go.mod h1:sY/eoe4ktxZE
 kmodules.xyz/client-go v0.0.0-20200521065424-173e32c78a20/go.mod h1:sY/eoe4ktxZEoHpr5NpAQ5s22VSwTE8psJtKVeVgLRY=
 kmodules.xyz/client-go v0.0.0-20200522120609-c6430d66212f/go.mod h1:sY/eoe4ktxZEoHpr5NpAQ5s22VSwTE8psJtKVeVgLRY=
 kmodules.xyz/client-go v0.0.0-20200525195850-2fd180961371/go.mod h1:sY/eoe4ktxZEoHpr5NpAQ5s22VSwTE8psJtKVeVgLRY=
-kmodules.xyz/client-go v0.0.0-20200807163543-64a96054c515 h1:ABNbxlL5xFFRCEGOhQ6xXSIE13dPXyfX2Ht0Madp5jE=
-kmodules.xyz/client-go v0.0.0-20200807163543-64a96054c515/go.mod h1:sY/eoe4ktxZEoHpr5NpAQ5s22VSwTE8psJtKVeVgLRY=
 kmodules.xyz/client-go v0.0.0-20200818143024-600fef263e03 h1:z6TH0w3feBVETSPlQNRw4cq/M+d9IlMDRDfgbYmHRMI=
 kmodules.xyz/client-go v0.0.0-20200818143024-600fef263e03/go.mod h1:sY/eoe4ktxZEoHpr5NpAQ5s22VSwTE8psJtKVeVgLRY=
 kmodules.xyz/client-go v0.0.0-20200818171030-24b2ce405feb h1:0yIIoTfkhR4JAgx8UyXbP7oAveVAOcf66+D+20Uj/Uc=
@@ -1030,6 +1028,6 @@ sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 sigs.k8s.io/yaml v1.2.0 h1:kr/MCeFWJWTwyaHoR9c8EjH9OumOmoF9YGiZd7lFm/Q=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
 sourcegraph.com/sqs/pbtypes v0.0.0-20180604144634-d3ebe8f20ae4/go.mod h1:ketZ/q3QxT9HOBeFhu6RdvsftgpsbFHBF5Cas6cDKZ0=
-stash.appscode.dev/apimachinery v0.10.0-beta.1.0.20200817055640-692909fead2f h1:3BSozADnV+G9h2PXA0uC+Fn9efnZ1huTmm8+saZE5OA=
-stash.appscode.dev/apimachinery v0.10.0-beta.1.0.20200817055640-692909fead2f/go.mod h1:eXRYGS4tRLNLGAdJEGTZEejXMDyHydzZkOLcAE+va4g=
+stash.appscode.dev/apimachinery v0.10.0-rc.0 h1:eapfPKJjFFh+YlZtJ2KVdngHG0jvjl/hOBLkj1hHejI=
+stash.appscode.dev/apimachinery v0.10.0-rc.0/go.mod h1:TpdBIAiHCtpkUB13SDUyCZ6y+5wmzXBMAf9e72cSPO4=
 vbom.ml/util v0.0.0-20160121211510-db5cfe13f5cc/go.mod h1:so/NYdZXCz+E3ZpW0uAoCj6uzU2+8OWDFv/HxUSs7kI=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1164,7 +1164,7 @@ sigs.k8s.io/structured-merge-diff/v3/typed
 sigs.k8s.io/structured-merge-diff/v3/value
 # sigs.k8s.io/yaml v1.2.0
 sigs.k8s.io/yaml
-# stash.appscode.dev/apimachinery v0.10.0-beta.1.0.20200817055640-692909fead2f
+# stash.appscode.dev/apimachinery v0.10.0-rc.0
 stash.appscode.dev/apimachinery/apis
 stash.appscode.dev/apimachinery/apis/repositories
 stash.appscode.dev/apimachinery/apis/repositories/install

--- a/vendor/stash.appscode.dev/apimachinery/apis/stash/v1beta1/annotations.go
+++ b/vendor/stash.appscode.dev/apimachinery/apis/stash/v1beta1/annotations.go
@@ -24,7 +24,7 @@ const (
 	KeyTargetPaths     = StashKey + "/target-paths"
 	KeyVolumeMounts    = StashKey + "/volume-mounts"
 	KeySchedule        = StashKey + "/schedule"
-	KeyParams          = StashKey + "/params"
+	KeyParams          = "params.stash.appscode.com"
 
 	KeyLastAppliedBackupInvoker     = StashKey + "/last-applied-backup-invoker"
 	KeyLastAppliedBackupInvokerKind = StashKey + "/last-applied-backup-invoker-kind"


### PR DESCRIPTION
ProductLine: Stash
Release: v2020.08.26-rc.0
Release-tracker: https://github.com/stashed/CHANGELOG/pull/4
Signed-off-by: 1gtm <1gtm@appscode.com>