### PR TITLE
Prepare for release v0.11.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	kmodules.xyz/openshift v0.0.0-20200922211657-1ece16d36c18
 	kmodules.xyz/prober v0.0.0-20200922212142-743a6514664e
 	kmodules.xyz/webhook-runtime v0.0.0-20200922211931-8337935590de
-	stash.appscode.dev/apimachinery v0.11.1-0.20200928173325-6ed3a17b3541
+	stash.appscode.dev/apimachinery v0.11.2
 )
 
 replace bitbucket.org/ww/goautoneg => gomodules.xyz/goautoneg v0.0.0-20120707110453-a547fc61f48d

--- a/go.sum
+++ b/go.sum
@@ -989,8 +989,6 @@ kmodules.xyz/client-go v0.0.0-20200521065424-173e32c78a20/go.mod h1:sY/eoe4ktxZE
 kmodules.xyz/client-go v0.0.0-20200818143024-600fef263e03/go.mod h1:sY/eoe4ktxZEoHpr5NpAQ5s22VSwTE8psJtKVeVgLRY=
 kmodules.xyz/client-go v0.0.0-20200922200830-63d86b6e5b63 h1:luKlEul8LMhyyftoZN34+vboL9MWAeQpSAUZxaLZBGg=
 kmodules.xyz/client-go v0.0.0-20200922200830-63d86b6e5b63/go.mod h1:JZN34jqk6ZlR+QOnBPpnUVBab4rmfamqxfSvLaulBMY=
-kmodules.xyz/client-go v0.0.0-20200924114038-ef01fa7ccbed h1:xF+qTlIfCZ8R2ingWKcOg9ohrr8WNP+LO5IlBisPTvE=
-kmodules.xyz/client-go v0.0.0-20200924114038-ef01fa7ccbed/go.mod h1:JZN34jqk6ZlR+QOnBPpnUVBab4rmfamqxfSvLaulBMY=
 kmodules.xyz/client-go v0.0.0-20200929030759-cce6a3c623c1 h1:wig8NVgxE5ynY6dsGduWpkF8utYHU1RjepncNbaStNw=
 kmodules.xyz/client-go v0.0.0-20200929030759-cce6a3c623c1/go.mod h1:pnRh7gtJ6ErPJQBkQeRlpD95KRtxhD4eGrYagZEU8RM=
 kmodules.xyz/constants v0.0.0-20200506032633-a21e58ceec72 h1:0sM6nE7aJon/PSdqZTj0bKJlPyzobXkG0wVYKpjcJJE=
@@ -1031,6 +1029,6 @@ sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 sigs.k8s.io/yaml v1.2.0 h1:kr/MCeFWJWTwyaHoR9c8EjH9OumOmoF9YGiZd7lFm/Q=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
 sourcegraph.com/sqs/pbtypes v0.0.0-20180604144634-d3ebe8f20ae4/go.mod h1:ketZ/q3QxT9HOBeFhu6RdvsftgpsbFHBF5Cas6cDKZ0=
-stash.appscode.dev/apimachinery v0.11.1-0.20200928173325-6ed3a17b3541 h1:nZEuGjrOMfoacYEM+buHyTb+F3iwpfH6lSbhB7I+Z18=
-stash.appscode.dev/apimachinery v0.11.1-0.20200928173325-6ed3a17b3541/go.mod h1:txBRRww/eMQ1Z3BVvr7YzwvT9jC+txgN26L4Soj99kk=
+stash.appscode.dev/apimachinery v0.11.2 h1:ZbkbWWfAR0SOhhZHRnLcbsbsKh/7hBkqnjIFWXkvyeg=
+stash.appscode.dev/apimachinery v0.11.2/go.mod h1:9rK2Iz8tgbmyE0eiYS7plYbGxFsa80PCf0jvDNTroOY=
 vbom.ml/util v0.0.0-20160121211510-db5cfe13f5cc/go.mod h1:so/NYdZXCz+E3ZpW0uAoCj6uzU2+8OWDFv/HxUSs7kI=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1221,7 +1221,7 @@ sigs.k8s.io/structured-merge-diff/v3/typed
 sigs.k8s.io/structured-merge-diff/v3/value
 # sigs.k8s.io/yaml v1.2.0
 sigs.k8s.io/yaml
-# stash.appscode.dev/apimachinery v0.11.1-0.20200928173325-6ed3a17b3541
+# stash.appscode.dev/apimachinery v0.11.2
 stash.appscode.dev/apimachinery/apis
 stash.appscode.dev/apimachinery/apis/repositories
 stash.appscode.dev/apimachinery/apis/repositories/install

--- a/vendor/stash.appscode.dev/apimachinery/apis/repositories/v1alpha1/openapi_generated.go
+++ b/vendor/stash.appscode.dev/apimachinery/apis/repositories/v1alpha1/openapi_generated.go
@@ -15585,7 +15585,7 @@ func schema_kmodulesxyz_client_go_api_v1_CertificatePrivateKey(ref common.Refere
 				Properties: map[string]spec.Schema{
 					"encoding": {
 						SchemaProps: spec.SchemaProps{
-							Description: "The private key cryptography standards (PKCS) encoding for this certificate's private key to be encoded in. If provided, allowed values are \"pkcs1\" and \"pkcs8\" standing for PKCS#1 and PKCS#8, respectively. Defaults to PKCS#1 if not specified.",
+							Description: "The private key cryptography standards (PKCS) encoding for this certificate's private key to be encoded in. If provided, allowed values are \"pkcs1\" and \"pkcs8\" standing for PKCS#1 and PKCS#8, respectively. Defaults to PKCS#1 if not specified. See here for the difference between the formats: https://stackoverflow.com/a/48960291",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/vendor/stash.appscode.dev/apimachinery/apis/stash/v1alpha1/openapi_generated.go
+++ b/vendor/stash.appscode.dev/apimachinery/apis/stash/v1alpha1/openapi_generated.go
@@ -15597,7 +15597,7 @@ func schema_kmodulesxyz_client_go_api_v1_CertificatePrivateKey(ref common.Refere
 				Properties: map[string]spec.Schema{
 					"encoding": {
 						SchemaProps: spec.SchemaProps{
-							Description: "The private key cryptography standards (PKCS) encoding for this certificate's private key to be encoded in. If provided, allowed values are \"pkcs1\" and \"pkcs8\" standing for PKCS#1 and PKCS#8, respectively. Defaults to PKCS#1 if not specified.",
+							Description: "The private key cryptography standards (PKCS) encoding for this certificate's private key to be encoded in. If provided, allowed values are \"pkcs1\" and \"pkcs8\" standing for PKCS#1 and PKCS#8, respectively. Defaults to PKCS#1 if not specified. See here for the difference between the formats: https://stackoverflow.com/a/48960291",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/vendor/stash.appscode.dev/apimachinery/apis/stash/v1beta1/openapi_generated.go
+++ b/vendor/stash.appscode.dev/apimachinery/apis/stash/v1beta1/openapi_generated.go
@@ -15631,7 +15631,7 @@ func schema_kmodulesxyz_client_go_api_v1_CertificatePrivateKey(ref common.Refere
 				Properties: map[string]spec.Schema{
 					"encoding": {
 						SchemaProps: spec.SchemaProps{
-							Description: "The private key cryptography standards (PKCS) encoding for this certificate's private key to be encoded in. If provided, allowed values are \"pkcs1\" and \"pkcs8\" standing for PKCS#1 and PKCS#8, respectively. Defaults to PKCS#1 if not specified.",
+							Description: "The private key cryptography standards (PKCS) encoding for this certificate's private key to be encoded in. If provided, allowed values are \"pkcs1\" and \"pkcs8\" standing for PKCS#1 and PKCS#8, respectively. Defaults to PKCS#1 if not specified. See here for the difference between the formats: https://stackoverflow.com/a/48960291",
 							Type:        []string{"string"},
 							Format:      "",
 						},


### PR DESCRIPTION
ProductLine: Stash
Release: v2020.09.29
Release-tracker: https://github.com/stashed/CHANGELOG/pull/10
Signed-off-by: 1gtm <1gtm@appscode.com>