### PR TITLE
Prepare for release v0.11.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	kmodules.xyz/openshift v0.0.0-20201105073146-0da509a7d39f
 	kmodules.xyz/prober v0.0.0-20201105074402-a243b3a27fd8
 	kmodules.xyz/webhook-runtime v0.0.0-20201105073856-2dc7382b88c6
-	stash.appscode.dev/apimachinery v0.11.7
+	stash.appscode.dev/apimachinery v0.11.8
 )
 
 replace bitbucket.org/ww/goautoneg => gomodules.xyz/goautoneg v0.0.0-20120707110453-a547fc61f48d

--- a/go.sum
+++ b/go.sum
@@ -1157,8 +1157,6 @@ kmodules.xyz/client-go v0.0.0-20201208053851-a1d7be95e006/go.mod h1:WXDwZBmvrcLg
 kmodules.xyz/constants v0.0.0-20200923054614-6b87dbbae4d6 h1:9b61GdwFN3IC9tPmBvgXdo2kBlQKvyFUy5y4Q0fwB5E=
 kmodules.xyz/constants v0.0.0-20200923054614-6b87dbbae4d6/go.mod h1:DbiFk1bJ1KEO94t1SlAn7tzc+Zz95rSXgyUKa2nzPmY=
 kmodules.xyz/crd-schema-fuzz v0.0.0-20200922204806-c1426cd7fcf4/go.mod h1:WrO3fryNyFCgqqyWnwI89lnzWA7kN072Ehya7ELGfzE=
-kmodules.xyz/custom-resources v0.0.0-20201105075444-3c6af51b4f79 h1:BKPPUY/w0ac4R6g172zrejs+MLae2CHGqHCFpzrbRLc=
-kmodules.xyz/custom-resources v0.0.0-20201105075444-3c6af51b4f79/go.mod h1:/r3/eJ3LIfwGyBEVaobqUZRZGh7GJv5RJojj/bdD14Q=
 kmodules.xyz/custom-resources v0.0.0-20201124062543-bd8d35c21b0c h1:OIAnTI2yik4i1DSe23kO+89RMw/Eu6WUG/IQ++ivYNo=
 kmodules.xyz/custom-resources v0.0.0-20201124062543-bd8d35c21b0c/go.mod h1:/r3/eJ3LIfwGyBEVaobqUZRZGh7GJv5RJojj/bdD14Q=
 kmodules.xyz/objectstore-api v0.0.0-20201105133858-cbb2af88d50a h1:FJ8Fwn+BCalLuzkhjmyDf7Fuh19LBIEf/Fx/+xaYDB0=
@@ -1194,6 +1192,6 @@ sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 sigs.k8s.io/yaml v1.2.0 h1:kr/MCeFWJWTwyaHoR9c8EjH9OumOmoF9YGiZd7lFm/Q=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
 sourcegraph.com/sqs/pbtypes v0.0.0-20180604144634-d3ebe8f20ae4/go.mod h1:ketZ/q3QxT9HOBeFhu6RdvsftgpsbFHBF5Cas6cDKZ0=
-stash.appscode.dev/apimachinery v0.11.7 h1:NgAES2E1YWPAKJE7agHPOC9jGV2rFB/zW3XjRcSlyUo=
-stash.appscode.dev/apimachinery v0.11.7/go.mod h1:QnuI/VQTYxiT5ikxHqwOmqO96emPJPykbxfEp7pgjhk=
+stash.appscode.dev/apimachinery v0.11.8 h1:Po7gDpZqd+iQ8DR3zu1iJgIPQiFODPjiA6NIKhO2+7s=
+stash.appscode.dev/apimachinery v0.11.8/go.mod h1:s91NxOW9K/CLv9Cl9XVCzBLgdKqVcUOyc9VrYg0NNB0=
 vbom.ml/util v0.0.0-20160121211510-db5cfe13f5cc/go.mod h1:so/NYdZXCz+E3ZpW0uAoCj6uzU2+8OWDFv/HxUSs7kI=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1238,7 +1238,7 @@ sigs.k8s.io/structured-merge-diff/v3/typed
 sigs.k8s.io/structured-merge-diff/v3/value
 # sigs.k8s.io/yaml v1.2.0
 sigs.k8s.io/yaml
-# stash.appscode.dev/apimachinery v0.11.7
+# stash.appscode.dev/apimachinery v0.11.8
 stash.appscode.dev/apimachinery/apis
 stash.appscode.dev/apimachinery/apis/repositories
 stash.appscode.dev/apimachinery/apis/repositories/install

--- a/vendor/stash.appscode.dev/apimachinery/apis/repositories/v1alpha1/openapi_generated.go
+++ b/vendor/stash.appscode.dev/apimachinery/apis/repositories/v1alpha1/openapi_generated.go
@@ -15937,7 +15937,7 @@ func schema_custom_resources_apis_appcatalog_v1alpha1_AddKeyTransform(ref common
 						},
 					},
 				},
-				Required: []string{"key", "value", "stringValue"},
+				Required: []string{"key"},
 			},
 		},
 	}

--- a/vendor/stash.appscode.dev/apimachinery/apis/stash/v1alpha1/openapi_generated.go
+++ b/vendor/stash.appscode.dev/apimachinery/apis/stash/v1alpha1/openapi_generated.go
@@ -15949,7 +15949,7 @@ func schema_custom_resources_apis_appcatalog_v1alpha1_AddKeyTransform(ref common
 						},
 					},
 				},
-				Required: []string{"key", "value", "stringValue"},
+				Required: []string{"key"},
 			},
 		},
 	}

--- a/vendor/stash.appscode.dev/apimachinery/apis/stash/v1beta1/openapi_generated.go
+++ b/vendor/stash.appscode.dev/apimachinery/apis/stash/v1beta1/openapi_generated.go
@@ -15983,7 +15983,7 @@ func schema_custom_resources_apis_appcatalog_v1alpha1_AddKeyTransform(ref common
 						},
 					},
 				},
-				Required: []string{"key", "value", "stringValue"},
+				Required: []string{"key"},
 			},
 		},
 	}


### PR DESCRIPTION
ProductLine: Stash
Release: v2020.12.17
Release-tracker: https://github.com/stashed/CHANGELOG/pull/25
Signed-off-by: 1gtm <1gtm@appscode.com>