### PR TITLE
Prepare for release v0.15.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	kmodules.xyz/prober v0.0.0-20210618020259-5836fb959027
 	kmodules.xyz/resource-metadata v0.5.8-0.20210722055301-dcc1abc08aa0 // indirect
 	kmodules.xyz/webhook-runtime v0.0.0-20210716205500-e489faf01981
-	stash.appscode.dev/apimachinery v0.14.2-0.20210728022045-68cf54c06a1c
+	stash.appscode.dev/apimachinery v0.15.0
 )
 
 replace bitbucket.org/ww/goautoneg => gomodules.xyz/goautoneg v0.0.0-20120707110453-a547fc61f48d

--- a/go.sum
+++ b/go.sum
@@ -1261,5 +1261,5 @@ sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 sigs.k8s.io/yaml v1.2.0 h1:kr/MCeFWJWTwyaHoR9c8EjH9OumOmoF9YGiZd7lFm/Q=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
 sourcegraph.com/sourcegraph/appdash v0.0.0-20190731080439-ebfcffb1b5c0/go.mod h1:hI742Nqp5OhwiqlzhgfbWU4mW4yO10fP+LoT9WOswdU=
-stash.appscode.dev/apimachinery v0.14.2-0.20210728022045-68cf54c06a1c h1:Js3XqHiBnX8S25spHnSJQtNb4OYNxwz1q+KHfuQCzog=
-stash.appscode.dev/apimachinery v0.14.2-0.20210728022045-68cf54c06a1c/go.mod h1:ColOw+Y5IeI3DO5bu1WZWw2AAhinz99K6fKKVLNkd2U=
+stash.appscode.dev/apimachinery v0.15.0 h1:vpwPKV6LP4ieZ87/2ri3ms4r3ZnE8bES24y8bbLYxqE=
+stash.appscode.dev/apimachinery v0.15.0/go.mod h1:ColOw+Y5IeI3DO5bu1WZWw2AAhinz99K6fKKVLNkd2U=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1475,7 +1475,7 @@ sigs.k8s.io/structured-merge-diff/v4/typed
 sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.2.0
 sigs.k8s.io/yaml
-# stash.appscode.dev/apimachinery v0.14.2-0.20210728022045-68cf54c06a1c
+# stash.appscode.dev/apimachinery v0.15.0
 ## explicit
 stash.appscode.dev/apimachinery/apis
 stash.appscode.dev/apimachinery/apis/repositories


### PR DESCRIPTION
ProductLine: Stash
Release: v2021.08.02
Release-tracker: https://github.com/stashed/CHANGELOG/pull/39
Signed-off-by: 1gtm <1gtm@appscode.com>