### PR TITLE
Apply all pod level runtime settings to CronJob

### DIFF
--- a/pkg/controller/backup_configuration.go
+++ b/pkg/controller/backup_configuration.go
@@ -45,6 +45,7 @@ import (
 	core_util "kmodules.xyz/client-go/core/v1"
 	meta2 "kmodules.xyz/client-go/meta"
 	"kmodules.xyz/client-go/tools/queue"
+	ofst_util "kmodules.xyz/offshoot-api/util"
 	workload_api "kmodules.xyz/webhook-runtime/apis/workload/v1"
 )
 
@@ -427,14 +428,9 @@ func (c *StashController) EnsureBackupTriggeringCronJob(inv invoker.BackupInvoke
 			in.Spec.JobTemplate.Spec.Template.Spec.ServiceAccountName = serviceAccountName
 			in.Spec.JobTemplate.Spec.Template.Spec.ImagePullSecrets = imagePullSecrets
 
-			// only apply the pod level runtime settings that make sense for the CronJob
+			// apply all the pod level runtime settings even though they may make no sense in every context
 			if inv.RuntimeSettings.Pod != nil {
-				if len(inv.RuntimeSettings.Pod.ImagePullSecrets) != 0 {
-					in.Spec.JobTemplate.Spec.Template.Spec.ImagePullSecrets = inv.RuntimeSettings.Pod.ImagePullSecrets
-				}
-				if inv.RuntimeSettings.Pod.SecurityContext != nil {
-					in.Spec.JobTemplate.Spec.Template.Spec.SecurityContext = inv.RuntimeSettings.Pod.SecurityContext
-				}
+				ofst_util.ApplyPodRuntimeSettings(in.Spec.JobTemplate.Spec.Template.Spec, *inv.RuntimeSettings.Pod)
 			}
 
 			return in


### PR DESCRIPTION
Fixes #1395 

It is not possible to decide which pod level runtime settings make sense for the CronJob, because for each property there is a valid use case, but also there are use cases, where they are not required. There may also be use cases where the CronJob pod settings should be different from those of the Backup Session. This change could also be breaking in case the pod runtime settings of the Backup Configuration contains properties that should not be applied to the CronJob.

As a result, this change should only be seen as workaround and a better solution for configuring the CronJob should be provided in future releases.