### PR TITLE
Always keep the last completed BackupSession (when `backupHistoryLimit > 0`) even if outside of history limit

### DIFF
--- a/test/e2e/framework/backup_session.go
+++ b/test/e2e/framework/backup_session.go
@@ -168,16 +168,6 @@ func (fi *Invocation) EventuallyRunningBackupCompleted(invokerMeta metav1.Object
 	}, WaitTimeOut, PullInterval)
 }
 
-func (fi *Invocation) EventuallyBackupSessionCount(invokerMeta metav1.ObjectMeta, invokerKind string) GomegaAsyncAssertion {
-	return Eventually(func() int {
-		bsList, err := fi.GetBackupSessionsForInvoker(invokerMeta, invokerKind)
-		if err != nil {
-			return 0
-		}
-		return len(bsList.Items)
-	}, WaitTimeOut, PullInterval)
-}
-
 func (fi *Invocation) GetBackupSessionsForInvoker(invokerMeta metav1.ObjectMeta, invokerKind string) (*v1beta1.BackupSessionList, error) {
 	return fi.StashClient.StashV1beta1().BackupSessions(fi.namespace).List(context.TODO(), metav1.ListOptions{
 		LabelSelector: labels.SelectorFromSet(map[string]string{


### PR DESCRIPTION
Signed-off-by: Emruz Hossain <emruz@appscode.com>