### PR TITLE
Prepare for release v0.18.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	kmodules.xyz/openshift v0.0.0-20210618001443-f2507caa512f
 	kmodules.xyz/prober v0.0.0-20210618020259-5836fb959027
 	kmodules.xyz/webhook-runtime v0.0.0-20211116181908-909a755cc9d1
-	stash.appscode.dev/apimachinery v0.17.1-0.20220210134237-79d844fbde2c
+	stash.appscode.dev/apimachinery v0.18.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1295,5 +1295,5 @@ sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 sigs.k8s.io/yaml v1.2.0 h1:kr/MCeFWJWTwyaHoR9c8EjH9OumOmoF9YGiZd7lFm/Q=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
 sourcegraph.com/sourcegraph/appdash v0.0.0-20190731080439-ebfcffb1b5c0/go.mod h1:hI742Nqp5OhwiqlzhgfbWU4mW4yO10fP+LoT9WOswdU=
-stash.appscode.dev/apimachinery v0.17.1-0.20220210134237-79d844fbde2c h1:Lyyp0gQq9VhLIml9myRxC92VovU3oNvz/s0WsYxpxrE=
-stash.appscode.dev/apimachinery v0.17.1-0.20220210134237-79d844fbde2c/go.mod h1:MDzqJ66A2QZKAHRksfHT5crOD29a0S5Hfuy/D5hHAjw=
+stash.appscode.dev/apimachinery v0.18.0 h1:Mo5m3ffLKePJMPVWufGlFXas3rAwu96R9BeswSNkTrI=
+stash.appscode.dev/apimachinery v0.18.0/go.mod h1:MDzqJ66A2QZKAHRksfHT5crOD29a0S5Hfuy/D5hHAjw=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1582,7 +1582,7 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.2.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
-# stash.appscode.dev/apimachinery v0.17.1-0.20220210134237-79d844fbde2c
+# stash.appscode.dev/apimachinery v0.18.0
 ## explicit; go 1.17
 stash.appscode.dev/apimachinery/apis
 stash.appscode.dev/apimachinery/apis/repositories


### PR DESCRIPTION
ProductLine: Stash
Release: v2022.02.22
Release-tracker: https://github.com/stashed/CHANGELOG/pull/44
Signed-off-by: 1gtm <1gtm@appscode.com>