### PR TITLE
Prepare for release v0.19.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	kmodules.xyz/openshift v0.0.0-20210618001443-f2507caa512f
 	kmodules.xyz/prober v0.0.0-20220317043828-5ae0114adcad
 	kmodules.xyz/webhook-runtime v0.0.0-20220317222714-0ddfc9e4c221
-	stash.appscode.dev/apimachinery v0.18.1-0.20220329122136-6508ad7ebdef
+	stash.appscode.dev/apimachinery v0.19.0
 )
 
 require github.com/josharian/intern v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1331,5 +1331,5 @@ sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
 sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=
 sigs.k8s.io/yaml v1.3.0/go.mod h1:GeOyir5tyXNByN85N/dRIT9es5UQNerPYEKK56eTBm8=
 sourcegraph.com/sourcegraph/appdash v0.0.0-20190731080439-ebfcffb1b5c0/go.mod h1:hI742Nqp5OhwiqlzhgfbWU4mW4yO10fP+LoT9WOswdU=
-stash.appscode.dev/apimachinery v0.18.1-0.20220329122136-6508ad7ebdef h1:8WMEUoP2iw3JxDjTNePJixGBg83ffQyIPVbWcajMscc=
-stash.appscode.dev/apimachinery v0.18.1-0.20220329122136-6508ad7ebdef/go.mod h1:vgzwLa2KFxfbcrTS3gzhJLYmx4WdZpHfW9n8a7Hzhzc=
+stash.appscode.dev/apimachinery v0.19.0 h1:G4oBu55042Ewigtwz/7iICWSiamvomJD8SuFlrEm7x8=
+stash.appscode.dev/apimachinery v0.19.0/go.mod h1:vgzwLa2KFxfbcrTS3gzhJLYmx4WdZpHfW9n8a7Hzhzc=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1586,7 +1586,7 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.3.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
-# stash.appscode.dev/apimachinery v0.18.1-0.20220329122136-6508ad7ebdef
+# stash.appscode.dev/apimachinery v0.19.0
 ## explicit; go 1.17
 stash.appscode.dev/apimachinery/apis
 stash.appscode.dev/apimachinery/apis/repositories


### PR DESCRIPTION
ProductLine: Stash
Release: v2022.03.29
Release-tracker: https://github.com/stashed/CHANGELOG/pull/46
Signed-off-by: 1gtm <1gtm@appscode.com>