### PR TITLE
Prepare for release v0.22.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	kmodules.xyz/openshift v0.24.0
 	kmodules.xyz/prober v0.24.0
 	kmodules.xyz/webhook-runtime v0.24.0
-	stash.appscode.dev/apimachinery v0.21.1-0.20220709120130-c6c22dfcf170
+	stash.appscode.dev/apimachinery v0.22.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1641,5 +1641,5 @@ sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
 sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=
 sigs.k8s.io/yaml v1.3.0/go.mod h1:GeOyir5tyXNByN85N/dRIT9es5UQNerPYEKK56eTBm8=
-stash.appscode.dev/apimachinery v0.21.1-0.20220709120130-c6c22dfcf170 h1:HJlM+en1Cxgdml/byxk8i/2dd1O4c+iX0NpEtRKbb8o=
-stash.appscode.dev/apimachinery v0.21.1-0.20220709120130-c6c22dfcf170/go.mod h1:uzKMOt8OxE5YpSjRPR6DCkUA+Wn8McXQNPSaVARB0GM=
+stash.appscode.dev/apimachinery v0.22.0 h1:h3Y9fGlD5oNzvPpX9VmvNjsy6u8jsNZjZ2HRgRlCWkE=
+stash.appscode.dev/apimachinery v0.22.0/go.mod h1:uzKMOt8OxE5YpSjRPR6DCkUA+Wn8McXQNPSaVARB0GM=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1744,7 +1744,7 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.3.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
-# stash.appscode.dev/apimachinery v0.21.1-0.20220709120130-c6c22dfcf170
+# stash.appscode.dev/apimachinery v0.22.0
 ## explicit; go 1.18
 stash.appscode.dev/apimachinery/apis
 stash.appscode.dev/apimachinery/apis/repositories


### PR DESCRIPTION
ProductLine: Stash
Release: v2022.07.09
Release-tracker: https://github.com/stashed/CHANGELOG/pull/53
Signed-off-by: 1gtm <1gtm@appscode.com>