### PR TITLE
Prepare for release v0.23.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	kmodules.xyz/openshift v0.25.0
 	kmodules.xyz/prober v0.25.0
 	kmodules.xyz/webhook-runtime v0.25.0
-	stash.appscode.dev/apimachinery v0.22.1-0.20220926120533-92b9a652596a
+	stash.appscode.dev/apimachinery v0.23.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1389,5 +1389,5 @@ sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
 sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=
 sigs.k8s.io/yaml v1.3.0/go.mod h1:GeOyir5tyXNByN85N/dRIT9es5UQNerPYEKK56eTBm8=
-stash.appscode.dev/apimachinery v0.22.1-0.20220926120533-92b9a652596a h1:zzD84MLej/5yUU1GstdCaWCp2Rle88bWNhIPad/nS2k=
-stash.appscode.dev/apimachinery v0.22.1-0.20220926120533-92b9a652596a/go.mod h1:Tb1y/+h1r3+YdBvI5RYIC0tW1b8S+0pIb3iG0X7BOjo=
+stash.appscode.dev/apimachinery v0.23.0 h1:wEOxoVsnF7LtOFxgQyvW+5dlVe8bw6kLhUm2LrQM41s=
+stash.appscode.dev/apimachinery v0.23.0/go.mod h1:Tb1y/+h1r3+YdBvI5RYIC0tW1b8S+0pIb3iG0X7BOjo=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1770,7 +1770,7 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.3.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
-# stash.appscode.dev/apimachinery v0.22.1-0.20220926120533-92b9a652596a
+# stash.appscode.dev/apimachinery v0.23.0
 ## explicit; go 1.18
 stash.appscode.dev/apimachinery/apis
 stash.appscode.dev/apimachinery/apis/repositories


### PR DESCRIPTION
ProductLine: Stash
Release: v2022.09.29
Release-tracker: https://github.com/stashed/CHANGELOG/pull/56
Signed-off-by: 1gtm <1gtm@appscode.com>