### PR TITLE
Prepare for release v0.25.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	kmodules.xyz/openshift v0.25.0
 	kmodules.xyz/prober v0.25.0
 	kmodules.xyz/webhook-runtime v0.25.0
-	stash.appscode.dev/apimachinery v0.24.1-0.20230103053452-3f20f5fe078b
+	stash.appscode.dev/apimachinery v0.25.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1393,5 +1393,5 @@ sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
 sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=
 sigs.k8s.io/yaml v1.3.0/go.mod h1:GeOyir5tyXNByN85N/dRIT9es5UQNerPYEKK56eTBm8=
-stash.appscode.dev/apimachinery v0.24.1-0.20230103053452-3f20f5fe078b h1:W0qAo9g27HSoZXz6hrOeTC5+beIVX6RhARug2NILHGU=
-stash.appscode.dev/apimachinery v0.24.1-0.20230103053452-3f20f5fe078b/go.mod h1:AdK7wfKZXqlL5g30ceuMw/7nEVW3AOemQVWjc03sI3k=
+stash.appscode.dev/apimachinery v0.25.0 h1:+j8kc164AXd9p8CdeWsvlMLugVFlRGlbARqKz+pLgcQ=
+stash.appscode.dev/apimachinery v0.25.0/go.mod h1:AdK7wfKZXqlL5g30ceuMw/7nEVW3AOemQVWjc03sI3k=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1770,7 +1770,7 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.3.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
-# stash.appscode.dev/apimachinery v0.24.1-0.20230103053452-3f20f5fe078b
+# stash.appscode.dev/apimachinery v0.25.0
 ## explicit; go 1.18
 stash.appscode.dev/apimachinery/apis
 stash.appscode.dev/apimachinery/apis/repositories


### PR DESCRIPTION
ProductLine: Stash
Release: v2023.01.05
Release-tracker: https://github.com/stashed/CHANGELOG/pull/60
Signed-off-by: 1gtm <1gtm@appscode.com>