### PR TITLE
Bump to Restic v0.15.1.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ else
 	endif
 endif
 
-RESTIC_VER       := 0.13.1
+RESTIC_VER       := 0.15.1
 
 ###
 ### These variables should not need tweaking.


### PR DESCRIPTION
See #1504 for reason & test results. The e2e tests succeeded after changing the git branch name to `bump-to-restic-0-15-1`. Please let me know if I should re-apply this PR with the new branch name.